### PR TITLE
Improved the rift storage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,20 +150,20 @@ dependencies {
     runtimeOnly fg.deobf("curse.maven:the-one-probe-245211:3871444")
     
     // PipeZ - 1.19-1.0.6
-    compileOnly fg.deobf("curse.maven:pipez-443900:3877192")
-    runtimeOnly fg.deobf("curse.maven:pipez-443900:3877192")
+    // compileOnly fg.deobf("curse.maven:pipez-443900:3877192")
+    // runtimeOnly fg.deobf("curse.maven:pipez-443900:3877192")
     
     // Spark - 1.19-1.9.25
-    compileOnly fg.deobf("curse.maven:spark-361579:3875647")
-    runtimeOnly fg.deobf("curse.maven:spark-361579:3875647")
+    // compileOnly fg.deobf("curse.maven:spark-361579:3875647")
+    // runtimeOnly fg.deobf("curse.maven:spark-361579:3875647")
     
     // SolarGeneration - 1.19-5.0.1
-    compileOnly fg.deobf("curse.maven:solargeneration-336538:3873840")
-    runtimeOnly fg.deobf("curse.maven:solargeneration-336538:3873840")
+    // compileOnly fg.deobf("curse.maven:solargeneration-336538:3873840")
+    // runtimeOnly fg.deobf("curse.maven:solargeneration-336538:3873840")
     
     // EdivadLib - 1.19-1.0.2
-    compileOnly fg.deobf("curse.maven:edivadlib-638508:3864277")
-    runtimeOnly fg.deobf("curse.maven:edivadlib-638508:3864277")
+    // compileOnly fg.deobf("curse.maven:edivadlib-638508:3864277")
+    // runtimeOnly fg.deobf("curse.maven:edivadlib-638508:3864277")
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -148,6 +148,22 @@ dependencies {
     // TheOneProbe - 1.19-6.2.0
     compileOnly fg.deobf("curse.maven:the-one-probe-245211:3871444")
     runtimeOnly fg.deobf("curse.maven:the-one-probe-245211:3871444")
+    
+    // PipeZ - 1.19-1.0.6
+    compileOnly fg.deobf("curse.maven:pipez-443900:3877192")
+    runtimeOnly fg.deobf("curse.maven:pipez-443900:3877192")
+    
+    // Spark - 1.19-1.9.25
+    compileOnly fg.deobf("curse.maven:spark-361579:3875647")
+    runtimeOnly fg.deobf("curse.maven:spark-361579:3875647")
+    
+    // SolarGeneration - 1.19-5.0.1
+    compileOnly fg.deobf("curse.maven:solargeneration-336538:3873840")
+    runtimeOnly fg.deobf("curse.maven:solargeneration-336538:3873840")
+    
+    // EdivadLib - 1.19-1.0.2
+    compileOnly fg.deobf("curse.maven:edivadlib-638508:3864277")
+    runtimeOnly fg.deobf("curse.maven:edivadlib-638508:3864277")
 }
 
 jar {

--- a/src/main/java/dev/gigaherz/enderrift/ConfigValues.java
+++ b/src/main/java/dev/gigaherz/enderrift/ConfigValues.java
@@ -1,6 +1,5 @@
 package dev.gigaherz.enderrift;
 
-import com.google.common.collect.Lists;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;

--- a/src/main/java/dev/gigaherz/enderrift/EnderRiftMod.java
+++ b/src/main/java/dev/gigaherz/enderrift/EnderRiftMod.java
@@ -17,6 +17,8 @@ import dev.gigaherz.enderrift.automation.iface.InterfaceScreen;
 import dev.gigaherz.enderrift.automation.iface.InterfaceBlockEntity;
 import dev.gigaherz.enderrift.automation.proxy.ProxyBlock;
 import dev.gigaherz.enderrift.automation.proxy.ProxyBlockEntity;
+import dev.gigaherz.enderrift.debug.DebugItemBlock;
+import dev.gigaherz.enderrift.debug.DebugItemBlockEntity;
 import dev.gigaherz.enderrift.generator.GeneratorBlock;
 import dev.gigaherz.enderrift.generator.GeneratorContainer;
 import dev.gigaherz.enderrift.generator.GeneratorScreen;
@@ -27,9 +29,6 @@ import net.minecraft.core.NonNullList;
 import net.minecraft.data.tags.BlockTagsProvider;
 import net.minecraft.network.chat.Component;
 import net.minecraft.tags.BlockTags;
-import net.minecraft.world.entity.ai.village.poi.PoiType;
-import net.minecraft.world.entity.npc.VillagerProfession;
-import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.material.Material;
@@ -110,6 +109,7 @@ public class EnderRiftMod
         }
     };
 
+    public static final RegistryObject<Block> DEBUG_ITEM_BLOCK = BLOCKS.register("debug_item_block", () -> new DebugItemBlock(BlockBehaviour.Properties.of(Material.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F).dynamicShape()));
     public static final RegistryObject<Block> RIFT = BLOCKS.register("rift", () -> new RiftBlock(BlockBehaviour.Properties.of(Material.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F).dynamicShape()));
     public static final RegistryObject<StructureCornerBlock> STRUCTURE_CORNER = BLOCKS.register("structure_corner", () -> new StructureCornerBlock(BlockBehaviour.Properties.of(Material.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F).noLootTable()));
     public static final RegistryObject<StructureEdgeBlock> STRUCTURE_EDGE = BLOCKS.register("structure_edge", () -> new StructureEdgeBlock(BlockBehaviour.Properties.of(Material.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F).noLootTable()));
@@ -120,6 +120,7 @@ public class EnderRiftMod
     public static final RegistryObject<Block> DRIVER = BLOCKS.register("driver", () -> new DriverBlock(BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
     public static final RegistryObject<Block> GENERATOR = BLOCKS.register("generator", () -> new GeneratorBlock(BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
 
+    public static final RegistryObject<Item> DEBUG_ITEM_BLOCK_ITEM = ITEMS.register("debug_item_block", () -> new BlockItem(DEBUG_ITEM_BLOCK.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
     public static final RegistryObject<Item> RIFT_ITEM = ITEMS.register("rift", () -> new BlockItem(RIFT.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
     public static final RegistryObject<Item> STRUCTURE_CORNER_ITEM = ITEMS.register("structure_corner", () -> new BlockItemNC(STRUCTURE_CORNER.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
     public static final RegistryObject<Item> STRUCTURE_EDGE_ITEM = ITEMS.register("structure_edge", () -> new BlockItemNC(STRUCTURE_EDGE.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
@@ -131,6 +132,7 @@ public class EnderRiftMod
     public static final RegistryObject<Item> GENERATOR_ITEM = ITEMS.register("generator", () -> new BlockItem(GENERATOR.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
     public static final RegistryObject<Item> RIFT_ORB = ITEMS.register("rift_orb", () -> new RiftItem(new Item.Properties().stacksTo(16).tab(ENDERRIFT_CREATIVE_TAB)));
 
+    public static final RegistryObject<BlockEntityType<DebugItemBlockEntity>> DEBUG_ITEM_BLOCK_ENTITY = BLOCK_ENTITIES.register("debug_item_block", () -> BlockEntityType.Builder.of(DebugItemBlockEntity::new, DEBUG_ITEM_BLOCK.get()).build(null));
     public static final RegistryObject<BlockEntityType<RiftBlockEntity>> RIFT_BLOCK_ENTITY = BLOCK_ENTITIES.register("rift", () -> BlockEntityType.Builder.of(RiftBlockEntity::new, RIFT.get()).build(null));
     public static final RegistryObject<BlockEntityType<StructureCornerBlockEntity>> STRUCTURE_CORNER_BLOCK_ENTITY = BLOCK_ENTITIES.register("structure", () -> BlockEntityType.Builder.of(StructureCornerBlockEntity::new, STRUCTURE_CORNER.get()).build(null));
     public static final RegistryObject<BlockEntityType<InterfaceBlockEntity>> INTERFACE_BLOCK_ENTITY = BLOCK_ENTITIES.register("interface", () -> BlockEntityType.Builder.of(InterfaceBlockEntity::new, INTERFACE.get()).build(null));

--- a/src/main/java/dev/gigaherz/enderrift/EnderRiftMod.java
+++ b/src/main/java/dev/gigaherz/enderrift/EnderRiftMod.java
@@ -102,269 +102,269 @@ import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
 @Mod(EnderRiftMod.MODID)
 public class EnderRiftMod
 {
-	public static final String MODID = "enderrift";
+    public static final String MODID = "enderrift";
 
-	private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MODID);
-	private static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, MODID);
-	private static final DeferredRegister<BlockEntityType<?>> BLOCK_ENTITIES = DeferredRegister.create(ForgeRegistries.BLOCK_ENTITY_TYPES, MODID);
-	private static final DeferredRegister<RecipeSerializer<?>> RECIPE_SERIALIZERS = DeferredRegister.create(ForgeRegistries.RECIPE_SERIALIZERS, MODID);
-	private static final DeferredRegister<MenuType<?>> MENU_TYPES = DeferredRegister.create(ForgeRegistries.MENU_TYPES, MODID);
+    private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MODID);
+    private static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, MODID);
+    private static final DeferredRegister<BlockEntityType<?>> BLOCK_ENTITIES = DeferredRegister.create(ForgeRegistries.BLOCK_ENTITY_TYPES, MODID);
+    private static final DeferredRegister<RecipeSerializer<?>> RECIPE_SERIALIZERS = DeferredRegister.create(ForgeRegistries.RECIPE_SERIALIZERS, MODID);
+    private static final DeferredRegister<MenuType<?>> MENU_TYPES = DeferredRegister.create(ForgeRegistries.MENU_TYPES, MODID);
 
-	public static CreativeModeTab ENDERRIFT_CREATIVE_TAB = new CreativeModeTab("tabEnderRift")
-	{
-		@Override
-		public ItemStack makeIcon()
-		{
-			return new ItemStack(EnderRiftMod.RIFT_ORB.get());
-		}
-	};
+    public static CreativeModeTab ENDERRIFT_CREATIVE_TAB = new CreativeModeTab("tabEnderRift")
+    {
+        @Override
+        public ItemStack makeIcon()
+        {
+            return new ItemStack(EnderRiftMod.RIFT_ORB.get());
+        }
+    };
 
-	public static final RegistryObject<Block> DEBUG_ITEM_BLOCK = BLOCKS.register("debug_item_block", () -> new DebugItemBlock(BlockBehaviour.Properties.of(Material.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F).dynamicShape()));
-	public static final RegistryObject<Block> RIFT = BLOCKS.register("rift", () -> new RiftBlock(BlockBehaviour.Properties.of(Material.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F).dynamicShape()));
-	public static final RegistryObject<StructureCornerBlock> STRUCTURE_CORNER = BLOCKS.register("structure_corner", () -> new StructureCornerBlock(BlockBehaviour.Properties.of(Material.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F).noLootTable()));
-	public static final RegistryObject<StructureEdgeBlock> STRUCTURE_EDGE = BLOCKS.register("structure_edge", () -> new StructureEdgeBlock(BlockBehaviour.Properties.of(Material.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F).noLootTable()));
-	public static final RegistryObject<Block> INTERFACE = BLOCKS.register("interface", () -> new InterfaceBlock(BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
-	public static final RegistryObject<Block> BROWSER = BLOCKS.register("browser", () -> new BrowserBlock(false, BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
-	public static final RegistryObject<Block> CRAFTING_BROWSER = BLOCKS.register("crafting_browser", () -> new BrowserBlock(true, BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
-	public static final RegistryObject<Block> PROXY = BLOCKS.register("proxy", () -> new ProxyBlock(BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
-	public static final RegistryObject<Block> DRIVER = BLOCKS.register("driver", () -> new DriverBlock(BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
-	public static final RegistryObject<Block> GENERATOR = BLOCKS.register("generator", () -> new GeneratorBlock(BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
+    public static final RegistryObject<Block> DEBUG_ITEM_BLOCK = BLOCKS.register("debug_item_block", () -> new DebugItemBlock(BlockBehaviour.Properties.of(Material.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F).dynamicShape()));
+    public static final RegistryObject<Block> RIFT = BLOCKS.register("rift", () -> new RiftBlock(BlockBehaviour.Properties.of(Material.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F).dynamicShape()));
+    public static final RegistryObject<StructureCornerBlock> STRUCTURE_CORNER = BLOCKS.register("structure_corner", () -> new StructureCornerBlock(BlockBehaviour.Properties.of(Material.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F).noLootTable()));
+    public static final RegistryObject<StructureEdgeBlock> STRUCTURE_EDGE = BLOCKS.register("structure_edge", () -> new StructureEdgeBlock(BlockBehaviour.Properties.of(Material.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F).noLootTable()));
+    public static final RegistryObject<Block> INTERFACE = BLOCKS.register("interface", () -> new InterfaceBlock(BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
+    public static final RegistryObject<Block> BROWSER = BLOCKS.register("browser", () -> new BrowserBlock(false, BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
+    public static final RegistryObject<Block> CRAFTING_BROWSER = BLOCKS.register("crafting_browser", () -> new BrowserBlock(true, BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
+    public static final RegistryObject<Block> PROXY = BLOCKS.register("proxy", () -> new ProxyBlock(BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
+    public static final RegistryObject<Block> DRIVER = BLOCKS.register("driver", () -> new DriverBlock(BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
+    public static final RegistryObject<Block> GENERATOR = BLOCKS.register("generator", () -> new GeneratorBlock(BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
 
-	public static final RegistryObject<Item> DEBUG_ITEM_BLOCK_ITEM = ITEMS.register("debug_item_block", () -> new BlockItem(DEBUG_ITEM_BLOCK.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
-	public static final RegistryObject<Item> RIFT_ITEM = ITEMS.register("rift", () -> new BlockItem(RIFT.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
-	public static final RegistryObject<Item> STRUCTURE_CORNER_ITEM = ITEMS.register("structure_corner", () -> new BlockItemNC(STRUCTURE_CORNER.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
-	public static final RegistryObject<Item> STRUCTURE_EDGE_ITEM = ITEMS.register("structure_edge", () -> new BlockItemNC(STRUCTURE_EDGE.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
-	public static final RegistryObject<Item> INTERFACE_ITEM = ITEMS.register("interface", () -> new BlockItem(INTERFACE.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
-	public static final RegistryObject<Item> BROWSER_ITEM = ITEMS.register("browser", () -> new BlockItem(BROWSER.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
-	public static final RegistryObject<Item> CRAFTING_BROWSER_ITEM = ITEMS.register("crafting_browser", () -> new BlockItem(CRAFTING_BROWSER.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
-	public static final RegistryObject<Item> PROXY_ITEM = ITEMS.register("proxy", () -> new BlockItem(PROXY.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
-	public static final RegistryObject<Item> DRIVER_ITEM = ITEMS.register("driver", () -> new BlockItem(DRIVER.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
-	public static final RegistryObject<Item> GENERATOR_ITEM = ITEMS.register("generator", () -> new BlockItem(GENERATOR.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
-	public static final RegistryObject<Item> RIFT_ORB = ITEMS.register("rift_orb", () -> new RiftItem(new Item.Properties().stacksTo(16).tab(ENDERRIFT_CREATIVE_TAB)));
+    public static final RegistryObject<Item> DEBUG_ITEM_BLOCK_ITEM = ITEMS.register("debug_item_block", () -> new BlockItem(DEBUG_ITEM_BLOCK.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
+    public static final RegistryObject<Item> RIFT_ITEM = ITEMS.register("rift", () -> new BlockItem(RIFT.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
+    public static final RegistryObject<Item> STRUCTURE_CORNER_ITEM = ITEMS.register("structure_corner", () -> new BlockItemNC(STRUCTURE_CORNER.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
+    public static final RegistryObject<Item> STRUCTURE_EDGE_ITEM = ITEMS.register("structure_edge", () -> new BlockItemNC(STRUCTURE_EDGE.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
+    public static final RegistryObject<Item> INTERFACE_ITEM = ITEMS.register("interface", () -> new BlockItem(INTERFACE.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
+    public static final RegistryObject<Item> BROWSER_ITEM = ITEMS.register("browser", () -> new BlockItem(BROWSER.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
+    public static final RegistryObject<Item> CRAFTING_BROWSER_ITEM = ITEMS.register("crafting_browser", () -> new BlockItem(CRAFTING_BROWSER.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
+    public static final RegistryObject<Item> PROXY_ITEM = ITEMS.register("proxy", () -> new BlockItem(PROXY.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
+    public static final RegistryObject<Item> DRIVER_ITEM = ITEMS.register("driver", () -> new BlockItem(DRIVER.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
+    public static final RegistryObject<Item> GENERATOR_ITEM = ITEMS.register("generator", () -> new BlockItem(GENERATOR.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
+    public static final RegistryObject<Item> RIFT_ORB = ITEMS.register("rift_orb", () -> new RiftItem(new Item.Properties().stacksTo(16).tab(ENDERRIFT_CREATIVE_TAB)));
 
-	public static final RegistryObject<BlockEntityType<DebugItemBlockEntity>> DEBUG_ITEM_BLOCK_ENTITY = BLOCK_ENTITIES.register("debug_item_block", () -> BlockEntityType.Builder.of(DebugItemBlockEntity::new, DEBUG_ITEM_BLOCK.get()).build(null));
-	public static final RegistryObject<BlockEntityType<RiftBlockEntity>> RIFT_BLOCK_ENTITY = BLOCK_ENTITIES.register("rift", () -> BlockEntityType.Builder.of(RiftBlockEntity::new, RIFT.get()).build(null));
-	public static final RegistryObject<BlockEntityType<StructureCornerBlockEntity>> STRUCTURE_CORNER_BLOCK_ENTITY = BLOCK_ENTITIES.register("structure", () -> BlockEntityType.Builder.of(StructureCornerBlockEntity::new, STRUCTURE_CORNER.get()).build(null));
-	public static final RegistryObject<BlockEntityType<InterfaceBlockEntity>> INTERFACE_BLOCK_ENTITY = BLOCK_ENTITIES.register("interface", () -> BlockEntityType.Builder.of(InterfaceBlockEntity::new, INTERFACE.get()).build(null));
-	public static final RegistryObject<BlockEntityType<BrowserBlockEntity>> BROWSER_BLOCK_ENTITY = BLOCK_ENTITIES.register("browser", () -> BlockEntityType.Builder.of(BrowserBlockEntity::new, BROWSER.get(), CRAFTING_BROWSER.get()).build(null));
-	public static final RegistryObject<BlockEntityType<ProxyBlockEntity>> PROXY_BLOCK_ENTITY = BLOCK_ENTITIES.register("proxy", () -> BlockEntityType.Builder.of(ProxyBlockEntity::new, PROXY.get()).build(null));
-	public static final RegistryObject<BlockEntityType<DriverBlockEntity>> DRIVER_BLOCK_ENTITY = BLOCK_ENTITIES.register("driver", () -> BlockEntityType.Builder.of(DriverBlockEntity::new, DRIVER.get()).build(null));
-	public static final RegistryObject<BlockEntityType<GeneratorBlockEntity>> GENERATOR_BLOCK_ENTITY = BLOCK_ENTITIES.register("generator", () -> BlockEntityType.Builder.of(GeneratorBlockEntity::new, GENERATOR.get()).build(null));
+    public static final RegistryObject<BlockEntityType<DebugItemBlockEntity>> DEBUG_ITEM_BLOCK_ENTITY = BLOCK_ENTITIES.register("debug_item_block", () -> BlockEntityType.Builder.of(DebugItemBlockEntity::new, DEBUG_ITEM_BLOCK.get()).build(null));
+    public static final RegistryObject<BlockEntityType<RiftBlockEntity>> RIFT_BLOCK_ENTITY = BLOCK_ENTITIES.register("rift", () -> BlockEntityType.Builder.of(RiftBlockEntity::new, RIFT.get()).build(null));
+    public static final RegistryObject<BlockEntityType<StructureCornerBlockEntity>> STRUCTURE_CORNER_BLOCK_ENTITY = BLOCK_ENTITIES.register("structure", () -> BlockEntityType.Builder.of(StructureCornerBlockEntity::new, STRUCTURE_CORNER.get()).build(null));
+    public static final RegistryObject<BlockEntityType<InterfaceBlockEntity>> INTERFACE_BLOCK_ENTITY = BLOCK_ENTITIES.register("interface", () -> BlockEntityType.Builder.of(InterfaceBlockEntity::new, INTERFACE.get()).build(null));
+    public static final RegistryObject<BlockEntityType<BrowserBlockEntity>> BROWSER_BLOCK_ENTITY = BLOCK_ENTITIES.register("browser", () -> BlockEntityType.Builder.of(BrowserBlockEntity::new, BROWSER.get(), CRAFTING_BROWSER.get()).build(null));
+    public static final RegistryObject<BlockEntityType<ProxyBlockEntity>> PROXY_BLOCK_ENTITY = BLOCK_ENTITIES.register("proxy", () -> BlockEntityType.Builder.of(ProxyBlockEntity::new, PROXY.get()).build(null));
+    public static final RegistryObject<BlockEntityType<DriverBlockEntity>> DRIVER_BLOCK_ENTITY = BLOCK_ENTITIES.register("driver", () -> BlockEntityType.Builder.of(DriverBlockEntity::new, DRIVER.get()).build(null));
+    public static final RegistryObject<BlockEntityType<GeneratorBlockEntity>> GENERATOR_BLOCK_ENTITY = BLOCK_ENTITIES.register("generator", () -> BlockEntityType.Builder.of(GeneratorBlockEntity::new, GENERATOR.get()).build(null));
 
-	public static final RegistryObject<MenuType<BrowserContainer>> BROWSER_MENU = MENU_TYPES.register("browser", () -> new MenuType<>(BrowserContainer::new));
-	public static final RegistryObject<MenuType<CraftingBrowserContainer>> CRAFTING_BROWSER_MENU = MENU_TYPES.register("crafting_browser", () -> new MenuType<>(CraftingBrowserContainer::new));
-	public static final RegistryObject<MenuType<InterfaceContainer>> INTERFACE_MENU = MENU_TYPES.register("interface", () -> new MenuType<>(InterfaceContainer::new));
-	public static final RegistryObject<MenuType<GeneratorContainer>> GENERATOR_MENU = MENU_TYPES.register("generator", () -> new MenuType<>(GeneratorContainer::new));
+    public static final RegistryObject<MenuType<BrowserContainer>> BROWSER_MENU = MENU_TYPES.register("browser", () -> new MenuType<>(BrowserContainer::new));
+    public static final RegistryObject<MenuType<CraftingBrowserContainer>> CRAFTING_BROWSER_MENU = MENU_TYPES.register("crafting_browser", () -> new MenuType<>(CraftingBrowserContainer::new));
+    public static final RegistryObject<MenuType<InterfaceContainer>> INTERFACE_MENU = MENU_TYPES.register("interface", () -> new MenuType<>(InterfaceContainer::new));
+    public static final RegistryObject<MenuType<GeneratorContainer>> GENERATOR_MENU = MENU_TYPES.register("generator", () -> new MenuType<>(GeneratorContainer::new));
 
-	public static final RegistryObject<SimpleRecipeSerializer<OrbDuplicationRecipe>> ORB_DUPLICATION = RECIPE_SERIALIZERS.register("orb_duplication", () -> new SimpleRecipeSerializer<>(OrbDuplicationRecipe::new));
+    public static final RegistryObject<SimpleRecipeSerializer<OrbDuplicationRecipe>> ORB_DUPLICATION = RECIPE_SERIALIZERS.register("orb_duplication", () -> new SimpleRecipeSerializer<>(OrbDuplicationRecipe::new));
 
-	private static final String PROTOCOL_VERSION = "1.1.0";
-	public static final SimpleChannel CHANNEL = NetworkRegistry.ChannelBuilder.named(new ResourceLocation(MODID, "main")).clientAcceptedVersions(PROTOCOL_VERSION::equals).serverAcceptedVersions(PROTOCOL_VERSION::equals).networkProtocolVersion(() -> PROTOCOL_VERSION).simpleChannel();
+    private static final String PROTOCOL_VERSION = "1.1.0";
+    public static final SimpleChannel CHANNEL = NetworkRegistry.ChannelBuilder.named(new ResourceLocation(MODID, "main")).clientAcceptedVersions(PROTOCOL_VERSION::equals).serverAcceptedVersions(PROTOCOL_VERSION::equals).networkProtocolVersion(() -> PROTOCOL_VERSION).simpleChannel();
 
-	public static final Logger logger = LogManager.getLogger(MODID);
+    public static final Logger logger = LogManager.getLogger(MODID);
 
-	public EnderRiftMod()
-	{
-		IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
+    public EnderRiftMod()
+    {
+        IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
 
-		ITEMS.register(modEventBus);
-		BLOCKS.register(modEventBus);
-		BLOCK_ENTITIES.register(modEventBus);
-		RECIPE_SERIALIZERS.register(modEventBus);
-		MENU_TYPES.register(modEventBus);
+        ITEMS.register(modEventBus);
+        BLOCKS.register(modEventBus);
+        BLOCK_ENTITIES.register(modEventBus);
+        RECIPE_SERIALIZERS.register(modEventBus);
+        MENU_TYPES.register(modEventBus);
 
-		modEventBus.addListener(this::commonSetup);
-		modEventBus.addListener(this::clientSetup);
-		modEventBus.addListener(this::interComms);
-		modEventBus.addListener(this::gatherData);
+        modEventBus.addListener(this::commonSetup);
+        modEventBus.addListener(this::clientSetup);
+        modEventBus.addListener(this::interComms);
+        modEventBus.addListener(this::gatherData);
 
-		MinecraftForge.EVENT_BUS.addListener(this::serverStart);
-		MinecraftForge.EVENT_BUS.addListener(this::serverStop);
-		MinecraftForge.EVENT_BUS.addListener(this::serverSave);
-		MinecraftForge.EVENT_BUS.addListener(this::commandEvent);
+        MinecraftForge.EVENT_BUS.addListener(this::serverStart);
+        MinecraftForge.EVENT_BUS.addListener(this::serverStop);
+        MinecraftForge.EVENT_BUS.addListener(this::serverSave);
+        MinecraftForge.EVENT_BUS.addListener(this::commandEvent);
 
-		ModLoadingContext modLoadingContext = ModLoadingContext.get();
-		modLoadingContext.registerConfig(ModConfig.Type.SERVER, ConfigValues.SERVER_SPEC);
-		// modLoadingContext.registerConfig(ModConfig.Type.CLIENT,
-		// ConfigData.CLIENT_SPEC);
-	}
+        ModLoadingContext modLoadingContext = ModLoadingContext.get();
+        modLoadingContext.registerConfig(ModConfig.Type.SERVER, ConfigValues.SERVER_SPEC);
+        // modLoadingContext.registerConfig(ModConfig.Type.CLIENT,
+        // ConfigData.CLIENT_SPEC);
+    }
 
-	public void commonSetup(FMLCommonSetupEvent event)
-	{
-		int messageNumber = 0;
-		CHANNEL.messageBuilder(ClearCraftingGrid.class, messageNumber++, NetworkDirection.PLAY_TO_SERVER).encoder(ClearCraftingGrid::encode).decoder(ClearCraftingGrid::new).consumerNetworkThread(ClearCraftingGrid::handle).add();
-		CHANNEL.messageBuilder(SendSlotChanges.class, messageNumber++, NetworkDirection.PLAY_TO_CLIENT).encoder(SendSlotChanges::encode).decoder(SendSlotChanges::new).consumerNetworkThread(SendSlotChanges::handle).add();
-		CHANNEL.messageBuilder(SetVisibleSlots.class, messageNumber++, NetworkDirection.PLAY_TO_SERVER).encoder(SetVisibleSlots::encode).decoder(SetVisibleSlots::new).consumerNetworkThread(SetVisibleSlots::handle).add();
-		logger.debug("Final message number: " + messageNumber);
+    public void commonSetup(FMLCommonSetupEvent event)
+    {
+        int messageNumber = 0;
+        CHANNEL.messageBuilder(ClearCraftingGrid.class, messageNumber++, NetworkDirection.PLAY_TO_SERVER).encoder(ClearCraftingGrid::encode).decoder(ClearCraftingGrid::new).consumerNetworkThread(ClearCraftingGrid::handle).add();
+        CHANNEL.messageBuilder(SendSlotChanges.class, messageNumber++, NetworkDirection.PLAY_TO_CLIENT).encoder(SendSlotChanges::encode).decoder(SendSlotChanges::new).consumerNetworkThread(SendSlotChanges::handle).add();
+        CHANNEL.messageBuilder(SetVisibleSlots.class, messageNumber++, NetworkDirection.PLAY_TO_SERVER).encoder(SetVisibleSlots::encode).decoder(SetVisibleSlots::new).consumerNetworkThread(SetVisibleSlots::handle).add();
+        logger.debug("Final message number: " + messageNumber);
 
-		RiftStructure.init();
-	}
+        RiftStructure.init();
+    }
 
-	public void clientSetup(FMLClientSetupEvent event)
-	{
-		MenuScreens.register(GENERATOR_MENU.get(), GeneratorScreen::new);
-		MenuScreens.register(INTERFACE_MENU.get(), InterfaceScreen::new);
-		MenuScreens.register(BROWSER_MENU.get(), BrowserScreen::new);
-		MenuScreens.register(CRAFTING_BROWSER_MENU.get(), CraftingBrowserScreen::new);
-	}
+    public void clientSetup(FMLClientSetupEvent event)
+    {
+        MenuScreens.register(GENERATOR_MENU.get(), GeneratorScreen::new);
+        MenuScreens.register(INTERFACE_MENU.get(), InterfaceScreen::new);
+        MenuScreens.register(BROWSER_MENU.get(), BrowserScreen::new);
+        MenuScreens.register(CRAFTING_BROWSER_MENU.get(), CraftingBrowserScreen::new);
+    }
 
-	public void serverStart(ServerAboutToStartEvent event)
-	{
-		RiftStorage.init(event.getServer());
-	}
+    public void serverStart(ServerAboutToStartEvent event)
+    {
+        RiftStorage.init(event.getServer());
+    }
 
-	public void serverSave(LevelEvent.Save event)
-	{
-		LevelAccessor levelAccessor = event.getLevel();
-		if (!(levelAccessor instanceof ServerLevel) || !((ServerLevel) levelAccessor).dimension().equals(Level.OVERWORLD) || !RiftStorage.isAvailable())
-		{
-			return;
-		}
-		RiftStorage.get().saveAll();
-	}
+    public void serverSave(LevelEvent.Save event)
+    {
+        LevelAccessor levelAccessor = event.getLevel();
+        if (!(levelAccessor instanceof ServerLevel) || !((ServerLevel) levelAccessor).dimension().equals(Level.OVERWORLD) || !RiftStorage.isAvailable())
+        {
+            return;
+        }
+        RiftStorage.get().saveAll();
+    }
 
-	public void serverStop(ServerStoppingEvent event)
-	{
-		RiftStorage.deinit();
-	}
+    public void serverStop(ServerStoppingEvent event)
+    {
+        RiftStorage.deinit();
+    }
 
-	public void interComms(InterModEnqueueEvent event)
-	{
-		InterModComms.sendTo("theoneprobe", "getTheOneProbe", () -> TheOneProbeProviders.create());
-	}
+    public void interComms(InterModEnqueueEvent event)
+    {
+        InterModComms.sendTo("theoneprobe", "getTheOneProbe", () -> TheOneProbeProviders.create());
+    }
 
-	public void commandEvent(RegisterCommandsEvent event)
-	{
-		event.getDispatcher().register(LiteralArgumentBuilder.<CommandSourceStack>literal("enderrift").then(Commands.literal("locate").then(Commands.argument("riftId", UuidArgument.uuid()).requires(cs -> cs.hasPermission(3)) // permission
-				.executes(this::locateSpecificRift)).requires(cs -> cs.hasPermission(3)) // permission
-				.executes(this::locateAllRifts)));
-	}
+    public void commandEvent(RegisterCommandsEvent event)
+    {
+        event.getDispatcher().register(LiteralArgumentBuilder.<CommandSourceStack>literal("enderrift").then(Commands.literal("locate").then(Commands.argument("riftId", UuidArgument.uuid()).requires(cs -> cs.hasPermission(3)) // permission
+                .executes(this::locateSpecificRift)).requires(cs -> cs.hasPermission(3)) // permission
+                .executes(this::locateAllRifts)));
+    }
 
-	private int locateSpecificRift(CommandContext<CommandSourceStack> context)
-	{
-		if (!RiftStorage.isAvailable())
-		{
-			context.getSource().sendFailure(Component.literal("Failed to retrieve RiftStorage"));
-			return 0;
-		}
-		UUID id = context.getArgument("riftId", UUID.class);
-		RiftHolder holder = RiftStorage.get().getRift(id);
-		if (holder == null || !holder.isValid())
-		{
-			context.getSource().sendFailure(Component.literal(String.format("Couldn't find rift with id '%s'", id)));
-			return 0;
-		}
-		locateRiftById(context, id, holder.getInventory());
-		return 0;
-	}
+    private int locateSpecificRift(CommandContext<CommandSourceStack> context)
+    {
+        if (!RiftStorage.isAvailable())
+        {
+            context.getSource().sendFailure(Component.literal("Failed to retrieve RiftStorage"));
+            return 0;
+        }
+        UUID id = context.getArgument("riftId", UUID.class);
+        RiftHolder holder = RiftStorage.get().getRift(id);
+        if (holder == null || !holder.isValid())
+        {
+            context.getSource().sendFailure(Component.literal(String.format("Couldn't find rift with id '%s'", id)));
+            return 0;
+        }
+        locateRiftById(context, id, holder.getInventory());
+        return 0;
+    }
 
-	private void locateRiftById(CommandContext<CommandSourceStack> context, UUID riftId, RiftInventory rift)
-	{
-		rift.locateListeners(context.getSource().getLevel(), (pos) -> context.getSource().sendSuccess(Component.literal(String.format("Found rift with id '%s' at %s %s %s", riftId, pos.getX(), pos.getY(), pos.getZ())).setStyle(Style.EMPTY.withClickEvent(new ClickEvent(Action.RUN_COMMAND, String.format("/tp %s %s %s", pos.getX(), pos.getY(), pos.getZ())))), true));
-	}
+    private void locateRiftById(CommandContext<CommandSourceStack> context, UUID riftId, RiftInventory rift)
+    {
+        rift.locateListeners(context.getSource().getLevel(), (pos) -> context.getSource().sendSuccess(Component.literal(String.format("Found rift with id '%s' at %s %s %s", riftId, pos.getX(), pos.getY(), pos.getZ())).setStyle(Style.EMPTY.withClickEvent(new ClickEvent(Action.RUN_COMMAND, String.format("/tp %s %s %s", pos.getX(), pos.getY(), pos.getZ())))), true));
+    }
 
-	private int locateAllRifts(CommandContext<CommandSourceStack> context)
-	{
-		RiftStorage.get().walkRifts((id, rift) -> locateRiftById(context, id, rift));
-		return 0;
-	}
+    private int locateAllRifts(CommandContext<CommandSourceStack> context)
+    {
+        RiftStorage.get().walkRifts((id, rift) -> locateRiftById(context, id, rift));
+        return 0;
+    }
 
-	public void gatherData(GatherDataEvent event)
-	{
-		Data.gatherData(event);
-	}
+    public void gatherData(GatherDataEvent event)
+    {
+        Data.gatherData(event);
+    }
 
-	public static ResourceLocation location(String path)
-	{
-		return new ResourceLocation(MODID, path);
-	}
+    public static ResourceLocation location(String path)
+    {
+        return new ResourceLocation(MODID, path);
+    }
 
-	public static class Data
-	{
-		public static void gatherData(GatherDataEvent event)
-		{
-			DataGenerator gen = event.getGenerator();
+    public static class Data
+    {
+        public static void gatherData(GatherDataEvent event)
+        {
+            DataGenerator gen = event.getGenerator();
 
-			gen.addProvider(event.includeServer(), new LootTableGen(gen));
-			gen.addProvider(event.includeServer(), new BlockTagGens(gen, event.getExistingFileHelper()));
-		}
+            gen.addProvider(event.includeServer(), new LootTableGen(gen));
+            gen.addProvider(event.includeServer(), new BlockTagGens(gen, event.getExistingFileHelper()));
+        }
 
-		private static class LootTableGen extends LootTableProvider implements DataProvider
-		{
-			public LootTableGen(DataGenerator gen)
-			{
-				super(gen);
-			}
+        private static class LootTableGen extends LootTableProvider implements DataProvider
+        {
+            public LootTableGen(DataGenerator gen)
+            {
+                super(gen);
+            }
 
-			private final List<Pair<Supplier<Consumer<BiConsumer<ResourceLocation, LootTable.Builder>>>, LootContextParamSet>> tables = ImmutableList.of(Pair.of(BlockTables::new, LootContextParamSets.BLOCK)
-			// Pair.of(FishingLootTables::new, LootParameterSets.FISHING),
-			// Pair.of(ChestLootTables::new, LootParameterSets.CHEST),
-			// Pair.of(EntityLootTables::new, LootParameterSets.ENTITY),
-			// Pair.of(GiftLootTables::new, LootParameterSets.GIFT)
-			);
+            private final List<Pair<Supplier<Consumer<BiConsumer<ResourceLocation, LootTable.Builder>>>, LootContextParamSet>> tables = ImmutableList.of(Pair.of(BlockTables::new, LootContextParamSets.BLOCK)
+            // Pair.of(FishingLootTables::new, LootParameterSets.FISHING),
+            // Pair.of(ChestLootTables::new, LootParameterSets.CHEST),
+            // Pair.of(EntityLootTables::new, LootParameterSets.ENTITY),
+            // Pair.of(GiftLootTables::new, LootParameterSets.GIFT)
+            );
 
-			@Override
-			protected List<Pair<Supplier<Consumer<BiConsumer<ResourceLocation, LootTable.Builder>>>, LootContextParamSet>> getTables()
-			{
-				return tables;
-			}
+            @Override
+            protected List<Pair<Supplier<Consumer<BiConsumer<ResourceLocation, LootTable.Builder>>>, LootContextParamSet>> getTables()
+            {
+                return tables;
+            }
 
-			@Override
-			protected void validate(Map<ResourceLocation, LootTable> map, ValidationContext validationtracker)
-			{
-				map.forEach((p_218436_2_, p_218436_3_) -> {
-					LootTables.validate(validationtracker, p_218436_2_, p_218436_3_);
-				});
-			}
+            @Override
+            protected void validate(Map<ResourceLocation, LootTable> map, ValidationContext validationtracker)
+            {
+                map.forEach((p_218436_2_, p_218436_3_) -> {
+                    LootTables.validate(validationtracker, p_218436_2_, p_218436_3_);
+                });
+            }
 
-			public static class BlockTables extends BlockLoot
-			{
-				@Override
-				protected void addTables()
-				{
-					this.dropSelf(GENERATOR.get());
-					this.dropSelf(DRIVER.get());
-					this.dropSelf(PROXY.get());
-					this.dropSelf(INTERFACE.get());
-					this.dropSelf(BROWSER.get());
-					this.dropSelf(CRAFTING_BROWSER.get());
-					this.dropSelf(RIFT.get());
-				}
+            public static class BlockTables extends BlockLoot
+            {
+                @Override
+                protected void addTables()
+                {
+                    this.dropSelf(GENERATOR.get());
+                    this.dropSelf(DRIVER.get());
+                    this.dropSelf(PROXY.get());
+                    this.dropSelf(INTERFACE.get());
+                    this.dropSelf(BROWSER.get());
+                    this.dropSelf(CRAFTING_BROWSER.get());
+                    this.dropSelf(RIFT.get());
+                }
 
-				@Override
-				protected Iterable<Block> getKnownBlocks()
-				{
-					return ForgeRegistries.BLOCKS.getEntries().stream().filter(e -> e.getKey().location().getNamespace().equals(EnderRiftMod.MODID)).map(Map.Entry::getValue).collect(Collectors.toList());
-				}
-			}
-		}
+                @Override
+                protected Iterable<Block> getKnownBlocks()
+                {
+                    return ForgeRegistries.BLOCKS.getEntries().stream().filter(e -> e.getKey().location().getNamespace().equals(EnderRiftMod.MODID)).map(Map.Entry::getValue).collect(Collectors.toList());
+                }
+            }
+        }
 
-		private static class BlockTagGens extends BlockTagsProvider implements DataProvider
-		{
-			public BlockTagGens(DataGenerator gen, ExistingFileHelper existingFileHelper)
-			{
-				super(gen, MODID, existingFileHelper);
-			}
+        private static class BlockTagGens extends BlockTagsProvider implements DataProvider
+        {
+            public BlockTagGens(DataGenerator gen, ExistingFileHelper existingFileHelper)
+            {
+                super(gen, MODID, existingFileHelper);
+            }
 
-			@Override
-			protected void addTags()
-			{
-				tag(BlockTags.MINEABLE_WITH_PICKAXE).add(BROWSER.get()).add(CRAFTING_BROWSER.get()).add(INTERFACE.get()).add(PROXY.get()).add(DRIVER.get()).add(RIFT.get()).add(GENERATOR.get()).add(STRUCTURE_CORNER.get()).add(STRUCTURE_EDGE.get());
-			}
-		}
-	}
+            @Override
+            protected void addTags()
+            {
+                tag(BlockTags.MINEABLE_WITH_PICKAXE).add(BROWSER.get()).add(CRAFTING_BROWSER.get()).add(INTERFACE.get()).add(PROXY.get()).add(DRIVER.get()).add(RIFT.get()).add(GENERATOR.get()).add(STRUCTURE_CORNER.get()).add(STRUCTURE_EDGE.get());
+            }
+        }
+    }
 
-	public static class BlockItemNC extends BlockItem
-	{
-		public BlockItemNC(Block pBlock, Properties pProperties)
-		{
-			super(pBlock, pProperties);
-		}
+    public static class BlockItemNC extends BlockItem
+    {
+        public BlockItemNC(Block pBlock, Properties pProperties)
+        {
+            super(pBlock, pProperties);
+        }
 
-		@Override
-		public void fillItemCategory(CreativeModeTab pGroup, NonNullList<ItemStack> pItems)
-		{
-			// do nothing
-		}
-	}
+        @Override
+        public void fillItemCategory(CreativeModeTab pGroup, NonNullList<ItemStack> pItems)
+        {
+            // do nothing
+        }
+    }
 }

--- a/src/main/java/dev/gigaherz/enderrift/EnderRiftMod.java
+++ b/src/main/java/dev/gigaherz/enderrift/EnderRiftMod.java
@@ -100,288 +100,271 @@ import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
 
 @Mod.EventBusSubscriber
 @Mod(EnderRiftMod.MODID)
-public class EnderRiftMod {
-    public static final String MODID = "enderrift";
+public class EnderRiftMod
+{
+	public static final String MODID = "enderrift";
 
-    private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MODID);
-    private static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, MODID);
-    private static final DeferredRegister<BlockEntityType<?>> BLOCK_ENTITIES = DeferredRegister.create(ForgeRegistries.BLOCK_ENTITY_TYPES,
-        MODID);
-    private static final DeferredRegister<RecipeSerializer<?>> RECIPE_SERIALIZERS = DeferredRegister
-        .create(ForgeRegistries.RECIPE_SERIALIZERS, MODID);
-    private static final DeferredRegister<MenuType<?>> MENU_TYPES = DeferredRegister.create(ForgeRegistries.MENU_TYPES, MODID);
+	private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MODID);
+	private static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, MODID);
+	private static final DeferredRegister<BlockEntityType<?>> BLOCK_ENTITIES = DeferredRegister.create(ForgeRegistries.BLOCK_ENTITY_TYPES, MODID);
+	private static final DeferredRegister<RecipeSerializer<?>> RECIPE_SERIALIZERS = DeferredRegister.create(ForgeRegistries.RECIPE_SERIALIZERS, MODID);
+	private static final DeferredRegister<MenuType<?>> MENU_TYPES = DeferredRegister.create(ForgeRegistries.MENU_TYPES, MODID);
 
-    public static CreativeModeTab ENDERRIFT_CREATIVE_TAB = new CreativeModeTab("tabEnderRift") {
-        @Override
-        public ItemStack makeIcon() {
-            return new ItemStack(EnderRiftMod.RIFT_ORB.get());
-        }
-    };
+	public static CreativeModeTab ENDERRIFT_CREATIVE_TAB = new CreativeModeTab("tabEnderRift")
+	{
+		@Override
+		public ItemStack makeIcon()
+		{
+			return new ItemStack(EnderRiftMod.RIFT_ORB.get());
+		}
+	};
 
-    public static final RegistryObject<Block> DEBUG_ITEM_BLOCK = BLOCKS.register("debug_item_block",
-        () -> new DebugItemBlock(BlockBehaviour.Properties.of(Material.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F).dynamicShape()));
-    public static final RegistryObject<Block> RIFT = BLOCKS.register("rift",
-        () -> new RiftBlock(BlockBehaviour.Properties.of(Material.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F).dynamicShape()));
-    public static final RegistryObject<StructureCornerBlock> STRUCTURE_CORNER = BLOCKS.register("structure_corner",
-        () -> new StructureCornerBlock(
-            BlockBehaviour.Properties.of(Material.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F).noLootTable()));
-    public static final RegistryObject<StructureEdgeBlock> STRUCTURE_EDGE = BLOCKS.register("structure_edge", () -> new StructureEdgeBlock(
-        BlockBehaviour.Properties.of(Material.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F).noLootTable()));
-    public static final RegistryObject<Block> INTERFACE = BLOCKS.register("interface", () -> new InterfaceBlock(
-        BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
-    public static final RegistryObject<Block> BROWSER = BLOCKS.register("browser", () -> new BrowserBlock(false,
-        BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
-    public static final RegistryObject<Block> CRAFTING_BROWSER = BLOCKS.register("crafting_browser", () -> new BrowserBlock(true,
-        BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
-    public static final RegistryObject<Block> PROXY = BLOCKS.register("proxy", () -> new ProxyBlock(
-        BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
-    public static final RegistryObject<Block> DRIVER = BLOCKS.register("driver", () -> new DriverBlock(
-        BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
-    public static final RegistryObject<Block> GENERATOR = BLOCKS.register("generator", () -> new GeneratorBlock(
-        BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
+	public static final RegistryObject<Block> DEBUG_ITEM_BLOCK = BLOCKS.register("debug_item_block", () -> new DebugItemBlock(BlockBehaviour.Properties.of(Material.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F).dynamicShape()));
+	public static final RegistryObject<Block> RIFT = BLOCKS.register("rift", () -> new RiftBlock(BlockBehaviour.Properties.of(Material.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F).dynamicShape()));
+	public static final RegistryObject<StructureCornerBlock> STRUCTURE_CORNER = BLOCKS.register("structure_corner", () -> new StructureCornerBlock(BlockBehaviour.Properties.of(Material.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F).noLootTable()));
+	public static final RegistryObject<StructureEdgeBlock> STRUCTURE_EDGE = BLOCKS.register("structure_edge", () -> new StructureEdgeBlock(BlockBehaviour.Properties.of(Material.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F).noLootTable()));
+	public static final RegistryObject<Block> INTERFACE = BLOCKS.register("interface", () -> new InterfaceBlock(BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
+	public static final RegistryObject<Block> BROWSER = BLOCKS.register("browser", () -> new BrowserBlock(false, BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
+	public static final RegistryObject<Block> CRAFTING_BROWSER = BLOCKS.register("crafting_browser", () -> new BrowserBlock(true, BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
+	public static final RegistryObject<Block> PROXY = BLOCKS.register("proxy", () -> new ProxyBlock(BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
+	public static final RegistryObject<Block> DRIVER = BLOCKS.register("driver", () -> new DriverBlock(BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
+	public static final RegistryObject<Block> GENERATOR = BLOCKS.register("generator", () -> new GeneratorBlock(BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
 
-    public static final RegistryObject<Item> DEBUG_ITEM_BLOCK_ITEM = ITEMS.register("debug_item_block",
-        () -> new BlockItem(DEBUG_ITEM_BLOCK.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
-    public static final RegistryObject<Item> RIFT_ITEM = ITEMS.register("rift",
-        () -> new BlockItem(RIFT.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
-    public static final RegistryObject<Item> STRUCTURE_CORNER_ITEM = ITEMS.register("structure_corner",
-        () -> new BlockItemNC(STRUCTURE_CORNER.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
-    public static final RegistryObject<Item> STRUCTURE_EDGE_ITEM = ITEMS.register("structure_edge",
-        () -> new BlockItemNC(STRUCTURE_EDGE.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
-    public static final RegistryObject<Item> INTERFACE_ITEM = ITEMS.register("interface",
-        () -> new BlockItem(INTERFACE.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
-    public static final RegistryObject<Item> BROWSER_ITEM = ITEMS.register("browser",
-        () -> new BlockItem(BROWSER.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
-    public static final RegistryObject<Item> CRAFTING_BROWSER_ITEM = ITEMS.register("crafting_browser",
-        () -> new BlockItem(CRAFTING_BROWSER.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
-    public static final RegistryObject<Item> PROXY_ITEM = ITEMS.register("proxy",
-        () -> new BlockItem(PROXY.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
-    public static final RegistryObject<Item> DRIVER_ITEM = ITEMS.register("driver",
-        () -> new BlockItem(DRIVER.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
-    public static final RegistryObject<Item> GENERATOR_ITEM = ITEMS.register("generator",
-        () -> new BlockItem(GENERATOR.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
-    public static final RegistryObject<Item> RIFT_ORB = ITEMS.register("rift_orb",
-        () -> new RiftItem(new Item.Properties().stacksTo(16).tab(ENDERRIFT_CREATIVE_TAB)));
+	public static final RegistryObject<Item> DEBUG_ITEM_BLOCK_ITEM = ITEMS.register("debug_item_block", () -> new BlockItem(DEBUG_ITEM_BLOCK.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
+	public static final RegistryObject<Item> RIFT_ITEM = ITEMS.register("rift", () -> new BlockItem(RIFT.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
+	public static final RegistryObject<Item> STRUCTURE_CORNER_ITEM = ITEMS.register("structure_corner", () -> new BlockItemNC(STRUCTURE_CORNER.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
+	public static final RegistryObject<Item> STRUCTURE_EDGE_ITEM = ITEMS.register("structure_edge", () -> new BlockItemNC(STRUCTURE_EDGE.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
+	public static final RegistryObject<Item> INTERFACE_ITEM = ITEMS.register("interface", () -> new BlockItem(INTERFACE.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
+	public static final RegistryObject<Item> BROWSER_ITEM = ITEMS.register("browser", () -> new BlockItem(BROWSER.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
+	public static final RegistryObject<Item> CRAFTING_BROWSER_ITEM = ITEMS.register("crafting_browser", () -> new BlockItem(CRAFTING_BROWSER.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
+	public static final RegistryObject<Item> PROXY_ITEM = ITEMS.register("proxy", () -> new BlockItem(PROXY.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
+	public static final RegistryObject<Item> DRIVER_ITEM = ITEMS.register("driver", () -> new BlockItem(DRIVER.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
+	public static final RegistryObject<Item> GENERATOR_ITEM = ITEMS.register("generator", () -> new BlockItem(GENERATOR.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
+	public static final RegistryObject<Item> RIFT_ORB = ITEMS.register("rift_orb", () -> new RiftItem(new Item.Properties().stacksTo(16).tab(ENDERRIFT_CREATIVE_TAB)));
 
-    public static final RegistryObject<BlockEntityType<DebugItemBlockEntity>> DEBUG_ITEM_BLOCK_ENTITY = BLOCK_ENTITIES
-        .register("debug_item_block", () -> BlockEntityType.Builder.of(DebugItemBlockEntity::new, DEBUG_ITEM_BLOCK.get()).build(null));
-    public static final RegistryObject<BlockEntityType<RiftBlockEntity>> RIFT_BLOCK_ENTITY = BLOCK_ENTITIES.register("rift",
-        () -> BlockEntityType.Builder.of(RiftBlockEntity::new, RIFT.get()).build(null));
-    public static final RegistryObject<BlockEntityType<StructureCornerBlockEntity>> STRUCTURE_CORNER_BLOCK_ENTITY = BLOCK_ENTITIES
-        .register("structure", () -> BlockEntityType.Builder.of(StructureCornerBlockEntity::new, STRUCTURE_CORNER.get()).build(null));
-    public static final RegistryObject<BlockEntityType<InterfaceBlockEntity>> INTERFACE_BLOCK_ENTITY = BLOCK_ENTITIES.register("interface",
-        () -> BlockEntityType.Builder.of(InterfaceBlockEntity::new, INTERFACE.get()).build(null));
-    public static final RegistryObject<BlockEntityType<BrowserBlockEntity>> BROWSER_BLOCK_ENTITY = BLOCK_ENTITIES.register("browser",
-        () -> BlockEntityType.Builder.of(BrowserBlockEntity::new, BROWSER.get(), CRAFTING_BROWSER.get()).build(null));
-    public static final RegistryObject<BlockEntityType<ProxyBlockEntity>> PROXY_BLOCK_ENTITY = BLOCK_ENTITIES.register("proxy",
-        () -> BlockEntityType.Builder.of(ProxyBlockEntity::new, PROXY.get()).build(null));
-    public static final RegistryObject<BlockEntityType<DriverBlockEntity>> DRIVER_BLOCK_ENTITY = BLOCK_ENTITIES.register("driver",
-        () -> BlockEntityType.Builder.of(DriverBlockEntity::new, DRIVER.get()).build(null));
-    public static final RegistryObject<BlockEntityType<GeneratorBlockEntity>> GENERATOR_BLOCK_ENTITY = BLOCK_ENTITIES.register("generator",
-        () -> BlockEntityType.Builder.of(GeneratorBlockEntity::new, GENERATOR.get()).build(null));
+	public static final RegistryObject<BlockEntityType<DebugItemBlockEntity>> DEBUG_ITEM_BLOCK_ENTITY = BLOCK_ENTITIES.register("debug_item_block", () -> BlockEntityType.Builder.of(DebugItemBlockEntity::new, DEBUG_ITEM_BLOCK.get()).build(null));
+	public static final RegistryObject<BlockEntityType<RiftBlockEntity>> RIFT_BLOCK_ENTITY = BLOCK_ENTITIES.register("rift", () -> BlockEntityType.Builder.of(RiftBlockEntity::new, RIFT.get()).build(null));
+	public static final RegistryObject<BlockEntityType<StructureCornerBlockEntity>> STRUCTURE_CORNER_BLOCK_ENTITY = BLOCK_ENTITIES.register("structure", () -> BlockEntityType.Builder.of(StructureCornerBlockEntity::new, STRUCTURE_CORNER.get()).build(null));
+	public static final RegistryObject<BlockEntityType<InterfaceBlockEntity>> INTERFACE_BLOCK_ENTITY = BLOCK_ENTITIES.register("interface", () -> BlockEntityType.Builder.of(InterfaceBlockEntity::new, INTERFACE.get()).build(null));
+	public static final RegistryObject<BlockEntityType<BrowserBlockEntity>> BROWSER_BLOCK_ENTITY = BLOCK_ENTITIES.register("browser", () -> BlockEntityType.Builder.of(BrowserBlockEntity::new, BROWSER.get(), CRAFTING_BROWSER.get()).build(null));
+	public static final RegistryObject<BlockEntityType<ProxyBlockEntity>> PROXY_BLOCK_ENTITY = BLOCK_ENTITIES.register("proxy", () -> BlockEntityType.Builder.of(ProxyBlockEntity::new, PROXY.get()).build(null));
+	public static final RegistryObject<BlockEntityType<DriverBlockEntity>> DRIVER_BLOCK_ENTITY = BLOCK_ENTITIES.register("driver", () -> BlockEntityType.Builder.of(DriverBlockEntity::new, DRIVER.get()).build(null));
+	public static final RegistryObject<BlockEntityType<GeneratorBlockEntity>> GENERATOR_BLOCK_ENTITY = BLOCK_ENTITIES.register("generator", () -> BlockEntityType.Builder.of(GeneratorBlockEntity::new, GENERATOR.get()).build(null));
 
-    public static final RegistryObject<MenuType<BrowserContainer>> BROWSER_MENU = MENU_TYPES.register("browser",
-        () -> new MenuType<>(BrowserContainer::new));
-    public static final RegistryObject<MenuType<CraftingBrowserContainer>> CRAFTING_BROWSER_MENU = MENU_TYPES.register("crafting_browser",
-        () -> new MenuType<>(CraftingBrowserContainer::new));
-    public static final RegistryObject<MenuType<InterfaceContainer>> INTERFACE_MENU = MENU_TYPES.register("interface",
-        () -> new MenuType<>(InterfaceContainer::new));
-    public static final RegistryObject<MenuType<GeneratorContainer>> GENERATOR_MENU = MENU_TYPES.register("generator",
-        () -> new MenuType<>(GeneratorContainer::new));
+	public static final RegistryObject<MenuType<BrowserContainer>> BROWSER_MENU = MENU_TYPES.register("browser", () -> new MenuType<>(BrowserContainer::new));
+	public static final RegistryObject<MenuType<CraftingBrowserContainer>> CRAFTING_BROWSER_MENU = MENU_TYPES.register("crafting_browser", () -> new MenuType<>(CraftingBrowserContainer::new));
+	public static final RegistryObject<MenuType<InterfaceContainer>> INTERFACE_MENU = MENU_TYPES.register("interface", () -> new MenuType<>(InterfaceContainer::new));
+	public static final RegistryObject<MenuType<GeneratorContainer>> GENERATOR_MENU = MENU_TYPES.register("generator", () -> new MenuType<>(GeneratorContainer::new));
 
-    public static final RegistryObject<SimpleRecipeSerializer<OrbDuplicationRecipe>> ORB_DUPLICATION = RECIPE_SERIALIZERS
-        .register("orb_duplication", () -> new SimpleRecipeSerializer<>(OrbDuplicationRecipe::new));
+	public static final RegistryObject<SimpleRecipeSerializer<OrbDuplicationRecipe>> ORB_DUPLICATION = RECIPE_SERIALIZERS.register("orb_duplication", () -> new SimpleRecipeSerializer<>(OrbDuplicationRecipe::new));
 
-    private static final String PROTOCOL_VERSION = "1.1.0";
-    public static final SimpleChannel CHANNEL = NetworkRegistry.ChannelBuilder.named(new ResourceLocation(MODID, "main"))
-        .clientAcceptedVersions(PROTOCOL_VERSION::equals).serverAcceptedVersions(PROTOCOL_VERSION::equals)
-        .networkProtocolVersion(() -> PROTOCOL_VERSION).simpleChannel();
+	private static final String PROTOCOL_VERSION = "1.1.0";
+	public static final SimpleChannel CHANNEL = NetworkRegistry.ChannelBuilder.named(new ResourceLocation(MODID, "main")).clientAcceptedVersions(PROTOCOL_VERSION::equals).serverAcceptedVersions(PROTOCOL_VERSION::equals).networkProtocolVersion(() -> PROTOCOL_VERSION).simpleChannel();
 
-    public static final Logger logger = LogManager.getLogger(MODID);
+	public static final Logger logger = LogManager.getLogger(MODID);
 
-    public EnderRiftMod() {
-        IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
+	public EnderRiftMod()
+	{
+		IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
 
-        ITEMS.register(modEventBus);
-        BLOCKS.register(modEventBus);
-        BLOCK_ENTITIES.register(modEventBus);
-        RECIPE_SERIALIZERS.register(modEventBus);
-        MENU_TYPES.register(modEventBus);
+		ITEMS.register(modEventBus);
+		BLOCKS.register(modEventBus);
+		BLOCK_ENTITIES.register(modEventBus);
+		RECIPE_SERIALIZERS.register(modEventBus);
+		MENU_TYPES.register(modEventBus);
 
-        modEventBus.addListener(this::commonSetup);
-        modEventBus.addListener(this::clientSetup);
-        modEventBus.addListener(this::interComms);
-        modEventBus.addListener(this::gatherData);
+		modEventBus.addListener(this::commonSetup);
+		modEventBus.addListener(this::clientSetup);
+		modEventBus.addListener(this::interComms);
+		modEventBus.addListener(this::gatherData);
 
-        MinecraftForge.EVENT_BUS.addListener(this::serverStart);
-        MinecraftForge.EVENT_BUS.addListener(this::serverStop);
-        MinecraftForge.EVENT_BUS.addListener(this::serverSave);
-        MinecraftForge.EVENT_BUS.addListener(this::commandEvent);
+		MinecraftForge.EVENT_BUS.addListener(this::serverStart);
+		MinecraftForge.EVENT_BUS.addListener(this::serverStop);
+		MinecraftForge.EVENT_BUS.addListener(this::serverSave);
+		MinecraftForge.EVENT_BUS.addListener(this::commandEvent);
 
-        ModLoadingContext modLoadingContext = ModLoadingContext.get();
-        modLoadingContext.registerConfig(ModConfig.Type.SERVER, ConfigValues.SERVER_SPEC);
-        //modLoadingContext.registerConfig(ModConfig.Type.CLIENT, ConfigData.CLIENT_SPEC);
-    }
+		ModLoadingContext modLoadingContext = ModLoadingContext.get();
+		modLoadingContext.registerConfig(ModConfig.Type.SERVER, ConfigValues.SERVER_SPEC);
+		// modLoadingContext.registerConfig(ModConfig.Type.CLIENT,
+		// ConfigData.CLIENT_SPEC);
+	}
 
-    public void commonSetup(FMLCommonSetupEvent event) {
-        int messageNumber = 0;
-        CHANNEL.messageBuilder(ClearCraftingGrid.class, messageNumber++, NetworkDirection.PLAY_TO_SERVER).encoder(ClearCraftingGrid::encode)
-            .decoder(ClearCraftingGrid::new).consumerNetworkThread(ClearCraftingGrid::handle).add();
-        CHANNEL.messageBuilder(SendSlotChanges.class, messageNumber++, NetworkDirection.PLAY_TO_CLIENT).encoder(SendSlotChanges::encode)
-            .decoder(SendSlotChanges::new).consumerNetworkThread(SendSlotChanges::handle).add();
-        CHANNEL.messageBuilder(SetVisibleSlots.class, messageNumber++, NetworkDirection.PLAY_TO_SERVER).encoder(SetVisibleSlots::encode)
-            .decoder(SetVisibleSlots::new).consumerNetworkThread(SetVisibleSlots::handle).add();
-        logger.debug("Final message number: " + messageNumber);
+	public void commonSetup(FMLCommonSetupEvent event)
+	{
+		int messageNumber = 0;
+		CHANNEL.messageBuilder(ClearCraftingGrid.class, messageNumber++, NetworkDirection.PLAY_TO_SERVER).encoder(ClearCraftingGrid::encode).decoder(ClearCraftingGrid::new).consumerNetworkThread(ClearCraftingGrid::handle).add();
+		CHANNEL.messageBuilder(SendSlotChanges.class, messageNumber++, NetworkDirection.PLAY_TO_CLIENT).encoder(SendSlotChanges::encode).decoder(SendSlotChanges::new).consumerNetworkThread(SendSlotChanges::handle).add();
+		CHANNEL.messageBuilder(SetVisibleSlots.class, messageNumber++, NetworkDirection.PLAY_TO_SERVER).encoder(SetVisibleSlots::encode).decoder(SetVisibleSlots::new).consumerNetworkThread(SetVisibleSlots::handle).add();
+		logger.debug("Final message number: " + messageNumber);
 
-        RiftStructure.init();
-    }
+		RiftStructure.init();
+	}
 
-    public void clientSetup(FMLClientSetupEvent event) {
-        MenuScreens.register(GENERATOR_MENU.get(), GeneratorScreen::new);
-        MenuScreens.register(INTERFACE_MENU.get(), InterfaceScreen::new);
-        MenuScreens.register(BROWSER_MENU.get(), BrowserScreen::new);
-        MenuScreens.register(CRAFTING_BROWSER_MENU.get(), CraftingBrowserScreen::new);
-    }
+	public void clientSetup(FMLClientSetupEvent event)
+	{
+		MenuScreens.register(GENERATOR_MENU.get(), GeneratorScreen::new);
+		MenuScreens.register(INTERFACE_MENU.get(), InterfaceScreen::new);
+		MenuScreens.register(BROWSER_MENU.get(), BrowserScreen::new);
+		MenuScreens.register(CRAFTING_BROWSER_MENU.get(), CraftingBrowserScreen::new);
+	}
 
-    public void serverStart(ServerAboutToStartEvent event) {
-        RiftStorage.init(event.getServer());
-    }
+	public void serverStart(ServerAboutToStartEvent event)
+	{
+		RiftStorage.init(event.getServer());
+	}
 
-    public void serverSave(LevelEvent.Save event) {
-        LevelAccessor levelAccessor = event.getLevel();
-        if (!(levelAccessor instanceof ServerLevel) || !((ServerLevel) levelAccessor).dimension().equals(Level.OVERWORLD) || !RiftStorage.isAvailable()) {
-            return;
-        }
-        RiftStorage.get().saveAll();
-    }
+	public void serverSave(LevelEvent.Save event)
+	{
+		LevelAccessor levelAccessor = event.getLevel();
+		if (!(levelAccessor instanceof ServerLevel) || !((ServerLevel) levelAccessor).dimension().equals(Level.OVERWORLD) || !RiftStorage.isAvailable())
+		{
+			return;
+		}
+		RiftStorage.get().saveAll();
+	}
 
-    public void serverStop(ServerStoppingEvent event) {
-        RiftStorage.deinit();
-    }
+	public void serverStop(ServerStoppingEvent event)
+	{
+		RiftStorage.deinit();
+	}
 
-    public void interComms(InterModEnqueueEvent event) {
-        InterModComms.sendTo("theoneprobe", "getTheOneProbe", () -> TheOneProbeProviders.create());
-    }
+	public void interComms(InterModEnqueueEvent event)
+	{
+		InterModComms.sendTo("theoneprobe", "getTheOneProbe", () -> TheOneProbeProviders.create());
+	}
 
-    public void commandEvent(RegisterCommandsEvent event) {
-        event.getDispatcher()
-            .register(LiteralArgumentBuilder.<CommandSourceStack>literal("enderrift")
-                .then(Commands.literal("locate").then(Commands.argument("riftId", UuidArgument.uuid()).requires(cs -> cs.hasPermission(3)) //permission
-                    .executes(this::locateSpecificRift)).requires(cs -> cs.hasPermission(3)) //permission
-                    .executes(this::locateAllRifts)));
-    }
+	public void commandEvent(RegisterCommandsEvent event)
+	{
+		event.getDispatcher().register(LiteralArgumentBuilder.<CommandSourceStack>literal("enderrift").then(Commands.literal("locate").then(Commands.argument("riftId", UuidArgument.uuid()).requires(cs -> cs.hasPermission(3)) // permission
+				.executes(this::locateSpecificRift)).requires(cs -> cs.hasPermission(3)) // permission
+				.executes(this::locateAllRifts)));
+	}
 
-    private int locateSpecificRift(CommandContext<CommandSourceStack> context) {
-        if (!RiftStorage.isAvailable()) {
-            context.getSource().sendFailure(Component.literal("Failed to retrieve RiftStorage"));
-            return 0;
-        }
-        UUID id = context.getArgument("riftId", UUID.class);
-        RiftHolder holder = RiftStorage.get().getRift(id);
-        if (holder == null || !holder.isValid()) {
-            context.getSource().sendFailure(Component.literal(String.format("Couldn't find rift with id '%s'", id)));
-            return 0;
-        }
-        locateRiftById(context, id, holder.getInventory());
-        return 0;
-    }
+	private int locateSpecificRift(CommandContext<CommandSourceStack> context)
+	{
+		if (!RiftStorage.isAvailable())
+		{
+			context.getSource().sendFailure(Component.literal("Failed to retrieve RiftStorage"));
+			return 0;
+		}
+		UUID id = context.getArgument("riftId", UUID.class);
+		RiftHolder holder = RiftStorage.get().getRift(id);
+		if (holder == null || !holder.isValid())
+		{
+			context.getSource().sendFailure(Component.literal(String.format("Couldn't find rift with id '%s'", id)));
+			return 0;
+		}
+		locateRiftById(context, id, holder.getInventory());
+		return 0;
+	}
 
-    private void locateRiftById(CommandContext<CommandSourceStack> context, UUID riftId, RiftInventory rift) {
-        rift.locateListeners(context.getSource().getLevel(), (pos) -> context.getSource().sendSuccess(
-            Component.literal(String.format("Found rift with id '%s' at %s %s %s", riftId, pos.getX(), pos.getY(), pos.getZ()))
-                .setStyle(Style.EMPTY
-                    .withClickEvent(new ClickEvent(Action.RUN_COMMAND, String.format("/tp %s %s %s", pos.getX(), pos.getY(), pos.getZ())))),
-            true));
-    }
+	private void locateRiftById(CommandContext<CommandSourceStack> context, UUID riftId, RiftInventory rift)
+	{
+		rift.locateListeners(context.getSource().getLevel(), (pos) -> context.getSource().sendSuccess(Component.literal(String.format("Found rift with id '%s' at %s %s %s", riftId, pos.getX(), pos.getY(), pos.getZ())).setStyle(Style.EMPTY.withClickEvent(new ClickEvent(Action.RUN_COMMAND, String.format("/tp %s %s %s", pos.getX(), pos.getY(), pos.getZ())))), true));
+	}
 
-    private int locateAllRifts(CommandContext<CommandSourceStack> context) {
-        RiftStorage.get().walkRifts((id, rift) -> locateRiftById(context, id, rift));
-        return 0;
-    }
+	private int locateAllRifts(CommandContext<CommandSourceStack> context)
+	{
+		RiftStorage.get().walkRifts((id, rift) -> locateRiftById(context, id, rift));
+		return 0;
+	}
 
-    public void gatherData(GatherDataEvent event) {
-        Data.gatherData(event);
-    }
+	public void gatherData(GatherDataEvent event)
+	{
+		Data.gatherData(event);
+	}
 
-    public static ResourceLocation location(String path) {
-        return new ResourceLocation(MODID, path);
-    }
+	public static ResourceLocation location(String path)
+	{
+		return new ResourceLocation(MODID, path);
+	}
 
-    public static class Data {
-        public static void gatherData(GatherDataEvent event) {
-            DataGenerator gen = event.getGenerator();
+	public static class Data
+	{
+		public static void gatherData(GatherDataEvent event)
+		{
+			DataGenerator gen = event.getGenerator();
 
-            gen.addProvider(event.includeServer(), new LootTableGen(gen));
-            gen.addProvider(event.includeServer(), new BlockTagGens(gen, event.getExistingFileHelper()));
-        }
+			gen.addProvider(event.includeServer(), new LootTableGen(gen));
+			gen.addProvider(event.includeServer(), new BlockTagGens(gen, event.getExistingFileHelper()));
+		}
 
-        private static class LootTableGen extends LootTableProvider implements DataProvider {
-            public LootTableGen(DataGenerator gen) {
-                super(gen);
-            }
+		private static class LootTableGen extends LootTableProvider implements DataProvider
+		{
+			public LootTableGen(DataGenerator gen)
+			{
+				super(gen);
+			}
 
-            private final List<Pair<Supplier<Consumer<BiConsumer<ResourceLocation, LootTable.Builder>>>, LootContextParamSet>> tables = ImmutableList
-                .of(Pair.of(BlockTables::new, LootContextParamSets.BLOCK)
-                //Pair.of(FishingLootTables::new, LootParameterSets.FISHING),
-                //Pair.of(ChestLootTables::new, LootParameterSets.CHEST),
-                //Pair.of(EntityLootTables::new, LootParameterSets.ENTITY),
-                //Pair.of(GiftLootTables::new, LootParameterSets.GIFT)
-                );
+			private final List<Pair<Supplier<Consumer<BiConsumer<ResourceLocation, LootTable.Builder>>>, LootContextParamSet>> tables = ImmutableList.of(Pair.of(BlockTables::new, LootContextParamSets.BLOCK)
+			// Pair.of(FishingLootTables::new, LootParameterSets.FISHING),
+			// Pair.of(ChestLootTables::new, LootParameterSets.CHEST),
+			// Pair.of(EntityLootTables::new, LootParameterSets.ENTITY),
+			// Pair.of(GiftLootTables::new, LootParameterSets.GIFT)
+			);
 
-            @Override
-            protected List<Pair<Supplier<Consumer<BiConsumer<ResourceLocation, LootTable.Builder>>>, LootContextParamSet>> getTables() {
-                return tables;
-            }
+			@Override
+			protected List<Pair<Supplier<Consumer<BiConsumer<ResourceLocation, LootTable.Builder>>>, LootContextParamSet>> getTables()
+			{
+				return tables;
+			}
 
-            @Override
-            protected void validate(Map<ResourceLocation, LootTable> map, ValidationContext validationtracker) {
-                map.forEach((p_218436_2_, p_218436_3_) -> {
-                    LootTables.validate(validationtracker, p_218436_2_, p_218436_3_);
-                });
-            }
+			@Override
+			protected void validate(Map<ResourceLocation, LootTable> map, ValidationContext validationtracker)
+			{
+				map.forEach((p_218436_2_, p_218436_3_) -> {
+					LootTables.validate(validationtracker, p_218436_2_, p_218436_3_);
+				});
+			}
 
-            public static class BlockTables extends BlockLoot {
-                @Override
-                protected void addTables() {
-                    this.dropSelf(GENERATOR.get());
-                    this.dropSelf(DRIVER.get());
-                    this.dropSelf(PROXY.get());
-                    this.dropSelf(INTERFACE.get());
-                    this.dropSelf(BROWSER.get());
-                    this.dropSelf(CRAFTING_BROWSER.get());
-                    this.dropSelf(RIFT.get());
-                }
+			public static class BlockTables extends BlockLoot
+			{
+				@Override
+				protected void addTables()
+				{
+					this.dropSelf(GENERATOR.get());
+					this.dropSelf(DRIVER.get());
+					this.dropSelf(PROXY.get());
+					this.dropSelf(INTERFACE.get());
+					this.dropSelf(BROWSER.get());
+					this.dropSelf(CRAFTING_BROWSER.get());
+					this.dropSelf(RIFT.get());
+				}
 
-                @Override
-                protected Iterable<Block> getKnownBlocks() {
-                    return ForgeRegistries.BLOCKS.getEntries().stream()
-                        .filter(e -> e.getKey().location().getNamespace().equals(EnderRiftMod.MODID)).map(Map.Entry::getValue)
-                        .collect(Collectors.toList());
-                }
-            }
-        }
+				@Override
+				protected Iterable<Block> getKnownBlocks()
+				{
+					return ForgeRegistries.BLOCKS.getEntries().stream().filter(e -> e.getKey().location().getNamespace().equals(EnderRiftMod.MODID)).map(Map.Entry::getValue).collect(Collectors.toList());
+				}
+			}
+		}
 
-        private static class BlockTagGens extends BlockTagsProvider implements DataProvider {
-            public BlockTagGens(DataGenerator gen, ExistingFileHelper existingFileHelper) {
-                super(gen, MODID, existingFileHelper);
-            }
+		private static class BlockTagGens extends BlockTagsProvider implements DataProvider
+		{
+			public BlockTagGens(DataGenerator gen, ExistingFileHelper existingFileHelper)
+			{
+				super(gen, MODID, existingFileHelper);
+			}
 
-            @Override
-            protected void addTags() {
-                tag(BlockTags.MINEABLE_WITH_PICKAXE).add(BROWSER.get()).add(CRAFTING_BROWSER.get()).add(INTERFACE.get()).add(PROXY.get())
-                    .add(DRIVER.get()).add(RIFT.get()).add(GENERATOR.get()).add(STRUCTURE_CORNER.get()).add(STRUCTURE_EDGE.get());
-            }
-        }
-    }
+			@Override
+			protected void addTags()
+			{
+				tag(BlockTags.MINEABLE_WITH_PICKAXE).add(BROWSER.get()).add(CRAFTING_BROWSER.get()).add(INTERFACE.get()).add(PROXY.get()).add(DRIVER.get()).add(RIFT.get()).add(GENERATOR.get()).add(STRUCTURE_CORNER.get()).add(STRUCTURE_EDGE.get());
+			}
+		}
+	}
 
-    public static class BlockItemNC extends BlockItem {
-        public BlockItemNC(Block pBlock, Properties pProperties) {
-            super(pBlock, pProperties);
-        }
+	public static class BlockItemNC extends BlockItem
+	{
+		public BlockItemNC(Block pBlock, Properties pProperties)
+		{
+			super(pBlock, pProperties);
+		}
 
-        @Override
-        public void fillItemCategory(CreativeModeTab pGroup, NonNullList<ItemStack> pItems) {
-            // do nothing
-        }
-    }
+		@Override
+		public void fillItemCategory(CreativeModeTab pGroup, NonNullList<ItemStack> pItems)
+		{
+			// do nothing
+		}
+	}
 }

--- a/src/main/java/dev/gigaherz/enderrift/EnderRiftMod.java
+++ b/src/main/java/dev/gigaherz/enderrift/EnderRiftMod.java
@@ -9,6 +9,9 @@ import dev.gigaherz.enderrift.automation.browser.*;
 import dev.gigaherz.enderrift.network.*;
 import dev.gigaherz.enderrift.plugins.TheOneProbeProviders;
 import dev.gigaherz.enderrift.rift.*;
+import dev.gigaherz.enderrift.rift.storage.RiftHolder;
+import dev.gigaherz.enderrift.rift.storage.RiftInventory;
+import dev.gigaherz.enderrift.rift.storage.RiftStorage;
 import dev.gigaherz.enderrift.automation.driver.DriverBlock;
 import dev.gigaherz.enderrift.automation.driver.DriverBlockEntity;
 import dev.gigaherz.enderrift.automation.iface.InterfaceBlock;
@@ -23,11 +26,12 @@ import dev.gigaherz.enderrift.generator.GeneratorBlock;
 import dev.gigaherz.enderrift.generator.GeneratorContainer;
 import dev.gigaherz.enderrift.generator.GeneratorScreen;
 import dev.gigaherz.enderrift.generator.GeneratorBlockEntity;
-import dev.gigaherz.enderrift.rift.storage.RiftInventory;
-import dev.gigaherz.enderrift.rift.storage.RiftStorage;
 import net.minecraft.core.NonNullList;
 import net.minecraft.data.tags.BlockTagsProvider;
+import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.ClickEvent.Action;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.Style;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.SoundType;
@@ -36,6 +40,7 @@ import net.minecraft.world.level.material.MaterialColor;
 import net.minecraft.client.gui.screens.MenuScreens;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
+import net.minecraft.commands.arguments.UuidArgument;
 import net.minecraft.data.DataGenerator;
 import net.minecraft.data.DataProvider;
 import net.minecraft.data.loot.LootTableProvider;
@@ -54,6 +59,8 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.data.ExistingFileHelper;
 import net.minecraftforge.data.event.GatherDataEvent;
 import net.minecraftforge.event.RegisterCommandsEvent;
+import net.minecraftforge.event.server.ServerStartedEvent;
+import net.minecraftforge.event.server.ServerStoppingEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.InterModComms;
 import net.minecraftforge.fml.ModLoadingContext;
@@ -74,6 +81,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -86,80 +94,108 @@ import net.minecraft.world.level.storage.loot.ValidationContext;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParamSet;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
 
-import net.minecraft.world.item.Item.Properties;
-
 @Mod.EventBusSubscriber
 @Mod(EnderRiftMod.MODID)
-public class EnderRiftMod
-{
+public class EnderRiftMod {
     public static final String MODID = "enderrift";
 
     private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MODID);
     private static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, MODID);
-    private static final DeferredRegister<BlockEntityType<?>> BLOCK_ENTITIES = DeferredRegister.create(ForgeRegistries.BLOCK_ENTITY_TYPES, MODID);
-    private static final DeferredRegister<RecipeSerializer<?>> RECIPE_SERIALIZERS = DeferredRegister.create(ForgeRegistries.RECIPE_SERIALIZERS, MODID);
+    private static final DeferredRegister<BlockEntityType<?>> BLOCK_ENTITIES = DeferredRegister.create(ForgeRegistries.BLOCK_ENTITY_TYPES,
+        MODID);
+    private static final DeferredRegister<RecipeSerializer<?>> RECIPE_SERIALIZERS = DeferredRegister
+        .create(ForgeRegistries.RECIPE_SERIALIZERS, MODID);
     private static final DeferredRegister<MenuType<?>> MENU_TYPES = DeferredRegister.create(ForgeRegistries.MENU_TYPES, MODID);
 
-    public static CreativeModeTab ENDERRIFT_CREATIVE_TAB = new CreativeModeTab("tabEnderRift")
-    {
+    public static CreativeModeTab ENDERRIFT_CREATIVE_TAB = new CreativeModeTab("tabEnderRift") {
         @Override
-        public ItemStack makeIcon()
-        {
+        public ItemStack makeIcon() {
             return new ItemStack(EnderRiftMod.RIFT_ORB.get());
         }
     };
 
-    public static final RegistryObject<Block> DEBUG_ITEM_BLOCK = BLOCKS.register("debug_item_block", () -> new DebugItemBlock(BlockBehaviour.Properties.of(Material.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F).dynamicShape()));
-    public static final RegistryObject<Block> RIFT = BLOCKS.register("rift", () -> new RiftBlock(BlockBehaviour.Properties.of(Material.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F).dynamicShape()));
-    public static final RegistryObject<StructureCornerBlock> STRUCTURE_CORNER = BLOCKS.register("structure_corner", () -> new StructureCornerBlock(BlockBehaviour.Properties.of(Material.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F).noLootTable()));
-    public static final RegistryObject<StructureEdgeBlock> STRUCTURE_EDGE = BLOCKS.register("structure_edge", () -> new StructureEdgeBlock(BlockBehaviour.Properties.of(Material.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F).noLootTable()));
-    public static final RegistryObject<Block> INTERFACE = BLOCKS.register("interface", () -> new InterfaceBlock(BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
-    public static final RegistryObject<Block> BROWSER = BLOCKS.register("browser", () -> new BrowserBlock(false, BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
-    public static final RegistryObject<Block> CRAFTING_BROWSER = BLOCKS.register("crafting_browser", () ->new BrowserBlock(true, BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
-    public static final RegistryObject<Block> PROXY = BLOCKS.register("proxy", () ->  new ProxyBlock(BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
-    public static final RegistryObject<Block> DRIVER = BLOCKS.register("driver", () -> new DriverBlock(BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
-    public static final RegistryObject<Block> GENERATOR = BLOCKS.register("generator", () -> new GeneratorBlock(BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
+    public static final RegistryObject<Block> DEBUG_ITEM_BLOCK = BLOCKS.register("debug_item_block",
+        () -> new DebugItemBlock(BlockBehaviour.Properties.of(Material.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F).dynamicShape()));
+    public static final RegistryObject<Block> RIFT = BLOCKS.register("rift",
+        () -> new RiftBlock(BlockBehaviour.Properties.of(Material.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F).dynamicShape()));
+    public static final RegistryObject<StructureCornerBlock> STRUCTURE_CORNER = BLOCKS.register("structure_corner",
+        () -> new StructureCornerBlock(
+            BlockBehaviour.Properties.of(Material.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F).noLootTable()));
+    public static final RegistryObject<StructureEdgeBlock> STRUCTURE_EDGE = BLOCKS.register("structure_edge", () -> new StructureEdgeBlock(
+        BlockBehaviour.Properties.of(Material.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F).noLootTable()));
+    public static final RegistryObject<Block> INTERFACE = BLOCKS.register("interface", () -> new InterfaceBlock(
+        BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
+    public static final RegistryObject<Block> BROWSER = BLOCKS.register("browser", () -> new BrowserBlock(false,
+        BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
+    public static final RegistryObject<Block> CRAFTING_BROWSER = BLOCKS.register("crafting_browser", () -> new BrowserBlock(true,
+        BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
+    public static final RegistryObject<Block> PROXY = BLOCKS.register("proxy", () -> new ProxyBlock(
+        BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
+    public static final RegistryObject<Block> DRIVER = BLOCKS.register("driver", () -> new DriverBlock(
+        BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
+    public static final RegistryObject<Block> GENERATOR = BLOCKS.register("generator", () -> new GeneratorBlock(
+        BlockBehaviour.Properties.of(Material.METAL, MaterialColor.STONE).sound(SoundType.METAL).strength(3.0F, 8.0F)));
 
-    public static final RegistryObject<Item> DEBUG_ITEM_BLOCK_ITEM = ITEMS.register("debug_item_block", () -> new BlockItem(DEBUG_ITEM_BLOCK.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
-    public static final RegistryObject<Item> RIFT_ITEM = ITEMS.register("rift", () -> new BlockItem(RIFT.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
-    public static final RegistryObject<Item> STRUCTURE_CORNER_ITEM = ITEMS.register("structure_corner", () -> new BlockItemNC(STRUCTURE_CORNER.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
-    public static final RegistryObject<Item> STRUCTURE_EDGE_ITEM = ITEMS.register("structure_edge", () -> new BlockItemNC(STRUCTURE_EDGE.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
-    public static final RegistryObject<Item> INTERFACE_ITEM = ITEMS.register("interface", () -> new BlockItem(INTERFACE.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
-    public static final RegistryObject<Item> BROWSER_ITEM = ITEMS.register("browser", () -> new BlockItem(BROWSER.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
-    public static final RegistryObject<Item> CRAFTING_BROWSER_ITEM = ITEMS.register("crafting_browser", () -> new BlockItem(CRAFTING_BROWSER.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
-    public static final RegistryObject<Item> PROXY_ITEM = ITEMS.register("proxy", () -> new BlockItem(PROXY.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
-    public static final RegistryObject<Item> DRIVER_ITEM = ITEMS.register("driver", () -> new BlockItem(DRIVER.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
-    public static final RegistryObject<Item> GENERATOR_ITEM = ITEMS.register("generator", () -> new BlockItem(GENERATOR.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
-    public static final RegistryObject<Item> RIFT_ORB = ITEMS.register("rift_orb", () -> new RiftItem(new Item.Properties().stacksTo(16).tab(ENDERRIFT_CREATIVE_TAB)));
+    public static final RegistryObject<Item> DEBUG_ITEM_BLOCK_ITEM = ITEMS.register("debug_item_block",
+        () -> new BlockItem(DEBUG_ITEM_BLOCK.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
+    public static final RegistryObject<Item> RIFT_ITEM = ITEMS.register("rift",
+        () -> new BlockItem(RIFT.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
+    public static final RegistryObject<Item> STRUCTURE_CORNER_ITEM = ITEMS.register("structure_corner",
+        () -> new BlockItemNC(STRUCTURE_CORNER.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
+    public static final RegistryObject<Item> STRUCTURE_EDGE_ITEM = ITEMS.register("structure_edge",
+        () -> new BlockItemNC(STRUCTURE_EDGE.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
+    public static final RegistryObject<Item> INTERFACE_ITEM = ITEMS.register("interface",
+        () -> new BlockItem(INTERFACE.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
+    public static final RegistryObject<Item> BROWSER_ITEM = ITEMS.register("browser",
+        () -> new BlockItem(BROWSER.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
+    public static final RegistryObject<Item> CRAFTING_BROWSER_ITEM = ITEMS.register("crafting_browser",
+        () -> new BlockItem(CRAFTING_BROWSER.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
+    public static final RegistryObject<Item> PROXY_ITEM = ITEMS.register("proxy",
+        () -> new BlockItem(PROXY.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
+    public static final RegistryObject<Item> DRIVER_ITEM = ITEMS.register("driver",
+        () -> new BlockItem(DRIVER.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
+    public static final RegistryObject<Item> GENERATOR_ITEM = ITEMS.register("generator",
+        () -> new BlockItem(GENERATOR.get(), new Item.Properties().tab(ENDERRIFT_CREATIVE_TAB)));
+    public static final RegistryObject<Item> RIFT_ORB = ITEMS.register("rift_orb",
+        () -> new RiftItem(new Item.Properties().stacksTo(16).tab(ENDERRIFT_CREATIVE_TAB)));
 
-    public static final RegistryObject<BlockEntityType<DebugItemBlockEntity>> DEBUG_ITEM_BLOCK_ENTITY = BLOCK_ENTITIES.register("debug_item_block", () -> BlockEntityType.Builder.of(DebugItemBlockEntity::new, DEBUG_ITEM_BLOCK.get()).build(null));
-    public static final RegistryObject<BlockEntityType<RiftBlockEntity>> RIFT_BLOCK_ENTITY = BLOCK_ENTITIES.register("rift", () -> BlockEntityType.Builder.of(RiftBlockEntity::new, RIFT.get()).build(null));
-    public static final RegistryObject<BlockEntityType<StructureCornerBlockEntity>> STRUCTURE_CORNER_BLOCK_ENTITY = BLOCK_ENTITIES.register("structure", () -> BlockEntityType.Builder.of(StructureCornerBlockEntity::new, STRUCTURE_CORNER.get()).build(null));
-    public static final RegistryObject<BlockEntityType<InterfaceBlockEntity>> INTERFACE_BLOCK_ENTITY = BLOCK_ENTITIES.register("interface", () -> BlockEntityType.Builder.of(InterfaceBlockEntity::new, INTERFACE.get()).build(null));
-    public static final RegistryObject<BlockEntityType<BrowserBlockEntity>> BROWSER_BLOCK_ENTITY = BLOCK_ENTITIES.register("browser", () -> BlockEntityType.Builder.of(BrowserBlockEntity::new, BROWSER.get(), CRAFTING_BROWSER.get()).build(null));
-    public static final RegistryObject<BlockEntityType<ProxyBlockEntity>> PROXY_BLOCK_ENTITY = BLOCK_ENTITIES.register("proxy", () -> BlockEntityType.Builder.of(ProxyBlockEntity::new, PROXY.get()).build(null));
-    public static final RegistryObject<BlockEntityType<DriverBlockEntity>> DRIVER_BLOCK_ENTITY = BLOCK_ENTITIES.register("driver", () -> BlockEntityType.Builder.of(DriverBlockEntity::new, DRIVER.get()).build(null));
-    public static final RegistryObject<BlockEntityType<GeneratorBlockEntity>> GENERATOR_BLOCK_ENTITY = BLOCK_ENTITIES.register("generator", () -> BlockEntityType.Builder.of(GeneratorBlockEntity::new, GENERATOR.get()).build(null));
+    public static final RegistryObject<BlockEntityType<DebugItemBlockEntity>> DEBUG_ITEM_BLOCK_ENTITY = BLOCK_ENTITIES
+        .register("debug_item_block", () -> BlockEntityType.Builder.of(DebugItemBlockEntity::new, DEBUG_ITEM_BLOCK.get()).build(null));
+    public static final RegistryObject<BlockEntityType<RiftBlockEntity>> RIFT_BLOCK_ENTITY = BLOCK_ENTITIES.register("rift",
+        () -> BlockEntityType.Builder.of(RiftBlockEntity::new, RIFT.get()).build(null));
+    public static final RegistryObject<BlockEntityType<StructureCornerBlockEntity>> STRUCTURE_CORNER_BLOCK_ENTITY = BLOCK_ENTITIES
+        .register("structure", () -> BlockEntityType.Builder.of(StructureCornerBlockEntity::new, STRUCTURE_CORNER.get()).build(null));
+    public static final RegistryObject<BlockEntityType<InterfaceBlockEntity>> INTERFACE_BLOCK_ENTITY = BLOCK_ENTITIES.register("interface",
+        () -> BlockEntityType.Builder.of(InterfaceBlockEntity::new, INTERFACE.get()).build(null));
+    public static final RegistryObject<BlockEntityType<BrowserBlockEntity>> BROWSER_BLOCK_ENTITY = BLOCK_ENTITIES.register("browser",
+        () -> BlockEntityType.Builder.of(BrowserBlockEntity::new, BROWSER.get(), CRAFTING_BROWSER.get()).build(null));
+    public static final RegistryObject<BlockEntityType<ProxyBlockEntity>> PROXY_BLOCK_ENTITY = BLOCK_ENTITIES.register("proxy",
+        () -> BlockEntityType.Builder.of(ProxyBlockEntity::new, PROXY.get()).build(null));
+    public static final RegistryObject<BlockEntityType<DriverBlockEntity>> DRIVER_BLOCK_ENTITY = BLOCK_ENTITIES.register("driver",
+        () -> BlockEntityType.Builder.of(DriverBlockEntity::new, DRIVER.get()).build(null));
+    public static final RegistryObject<BlockEntityType<GeneratorBlockEntity>> GENERATOR_BLOCK_ENTITY = BLOCK_ENTITIES.register("generator",
+        () -> BlockEntityType.Builder.of(GeneratorBlockEntity::new, GENERATOR.get()).build(null));
 
-    public static final RegistryObject<MenuType<BrowserContainer>> BROWSER_MENU = MENU_TYPES.register("browser", () -> new MenuType<>(BrowserContainer::new));
-    public static final RegistryObject<MenuType<CraftingBrowserContainer>> CRAFTING_BROWSER_MENU = MENU_TYPES.register("crafting_browser", () -> new MenuType<>(CraftingBrowserContainer::new));
-    public static final RegistryObject<MenuType<InterfaceContainer>> INTERFACE_MENU = MENU_TYPES.register("interface", () -> new MenuType<>(InterfaceContainer::new));
-    public static final RegistryObject<MenuType<GeneratorContainer>> GENERATOR_MENU = MENU_TYPES.register("generator", () -> new MenuType<>(GeneratorContainer::new));
+    public static final RegistryObject<MenuType<BrowserContainer>> BROWSER_MENU = MENU_TYPES.register("browser",
+        () -> new MenuType<>(BrowserContainer::new));
+    public static final RegistryObject<MenuType<CraftingBrowserContainer>> CRAFTING_BROWSER_MENU = MENU_TYPES.register("crafting_browser",
+        () -> new MenuType<>(CraftingBrowserContainer::new));
+    public static final RegistryObject<MenuType<InterfaceContainer>> INTERFACE_MENU = MENU_TYPES.register("interface",
+        () -> new MenuType<>(InterfaceContainer::new));
+    public static final RegistryObject<MenuType<GeneratorContainer>> GENERATOR_MENU = MENU_TYPES.register("generator",
+        () -> new MenuType<>(GeneratorContainer::new));
 
-    public static final RegistryObject<SimpleRecipeSerializer<OrbDuplicationRecipe>> ORB_DUPLICATION = RECIPE_SERIALIZERS.register("orb_duplication", () -> new SimpleRecipeSerializer<>(OrbDuplicationRecipe::new));
+    public static final RegistryObject<SimpleRecipeSerializer<OrbDuplicationRecipe>> ORB_DUPLICATION = RECIPE_SERIALIZERS
+        .register("orb_duplication", () -> new SimpleRecipeSerializer<>(OrbDuplicationRecipe::new));
 
     private static final String PROTOCOL_VERSION = "1.1.0";
-    public static final SimpleChannel CHANNEL = NetworkRegistry.ChannelBuilder
-            .named(new ResourceLocation(MODID, "main"))
-            .clientAcceptedVersions(PROTOCOL_VERSION::equals)
-            .serverAcceptedVersions(PROTOCOL_VERSION::equals)
-            .networkProtocolVersion(() -> PROTOCOL_VERSION)
-            .simpleChannel();
+    public static final SimpleChannel CHANNEL = NetworkRegistry.ChannelBuilder.named(new ResourceLocation(MODID, "main"))
+        .clientAcceptedVersions(PROTOCOL_VERSION::equals).serverAcceptedVersions(PROTOCOL_VERSION::equals)
+        .networkProtocolVersion(() -> PROTOCOL_VERSION).simpleChannel();
 
     public static final Logger logger = LogManager.getLogger(MODID);
 
-    public EnderRiftMod()
-    {
+    public EnderRiftMod() {
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
 
         ITEMS.register(modEventBus);
@@ -170,6 +206,8 @@ public class EnderRiftMod
 
         modEventBus.addListener(this::commonSetup);
         modEventBus.addListener(this::clientSetup);
+        modEventBus.addListener(this::serverStart);
+        modEventBus.addListener(this::serverStop);
         modEventBus.addListener(this::interComms);
         modEventBus.addListener(this::gatherData);
 
@@ -180,121 +218,118 @@ public class EnderRiftMod
         //modLoadingContext.registerConfig(ModConfig.Type.CLIENT, ConfigData.CLIENT_SPEC);
     }
 
-    public void commonSetup(FMLCommonSetupEvent event)
-    {
+    public void commonSetup(FMLCommonSetupEvent event) {
         int messageNumber = 0;
-        CHANNEL.messageBuilder(ClearCraftingGrid.class, messageNumber++, NetworkDirection.PLAY_TO_SERVER).encoder(ClearCraftingGrid::encode).decoder(ClearCraftingGrid::new).consumerNetworkThread(ClearCraftingGrid::handle).add();
-        CHANNEL.messageBuilder(SendSlotChanges.class, messageNumber++, NetworkDirection.PLAY_TO_CLIENT).encoder(SendSlotChanges::encode).decoder(SendSlotChanges::new).consumerNetworkThread(SendSlotChanges::handle).add();
-        CHANNEL.messageBuilder(SetVisibleSlots.class, messageNumber++, NetworkDirection.PLAY_TO_SERVER).encoder(SetVisibleSlots::encode).decoder(SetVisibleSlots::new).consumerNetworkThread(SetVisibleSlots::handle).add();
+        CHANNEL.messageBuilder(ClearCraftingGrid.class, messageNumber++, NetworkDirection.PLAY_TO_SERVER).encoder(ClearCraftingGrid::encode)
+            .decoder(ClearCraftingGrid::new).consumerNetworkThread(ClearCraftingGrid::handle).add();
+        CHANNEL.messageBuilder(SendSlotChanges.class, messageNumber++, NetworkDirection.PLAY_TO_CLIENT).encoder(SendSlotChanges::encode)
+            .decoder(SendSlotChanges::new).consumerNetworkThread(SendSlotChanges::handle).add();
+        CHANNEL.messageBuilder(SetVisibleSlots.class, messageNumber++, NetworkDirection.PLAY_TO_SERVER).encoder(SetVisibleSlots::encode)
+            .decoder(SetVisibleSlots::new).consumerNetworkThread(SetVisibleSlots::handle).add();
         logger.debug("Final message number: " + messageNumber);
 
         RiftStructure.init();
     }
 
-    public void clientSetup(FMLClientSetupEvent event)
-    {
+    public void clientSetup(FMLClientSetupEvent event) {
         MenuScreens.register(GENERATOR_MENU.get(), GeneratorScreen::new);
         MenuScreens.register(INTERFACE_MENU.get(), InterfaceScreen::new);
         MenuScreens.register(BROWSER_MENU.get(), BrowserScreen::new);
         MenuScreens.register(CRAFTING_BROWSER_MENU.get(), CraftingBrowserScreen::new);
     }
 
-    public void interComms(InterModEnqueueEvent event)
-    {
+    public void serverStart(ServerStartedEvent event) {
+        RiftStorage.init(event.getServer());
+    }
+
+    public void serverStop(ServerStoppingEvent event) {
+        RiftStorage.deinit();
+    }
+
+    public void interComms(InterModEnqueueEvent event) {
         InterModComms.sendTo("theoneprobe", "getTheOneProbe", () -> TheOneProbeProviders.create());
     }
 
-    public void commandEvent(RegisterCommandsEvent event)
-    {
-        event.getDispatcher().register(
-                LiteralArgumentBuilder.<CommandSourceStack>literal("enderrift")
-                    .then(Commands.literal("locate")
-                            .then(Commands.argument("riftId", IntegerArgumentType.integer(1))
-                                    .requires(cs->cs.hasPermission(3)) //permission
-                                    .executes(this::locateSpecificRift)
-                            )
-                            .requires(cs->cs.hasPermission(3)) //permission
-                            .executes(this::locateAllRifts)
-                    )
-        );
+    public void commandEvent(RegisterCommandsEvent event) {
+        event.getDispatcher()
+            .register(LiteralArgumentBuilder.<CommandSourceStack>literal("enderrift")
+                .then(Commands.literal("locate").then(Commands.argument("riftId", UuidArgument.uuid()).requires(cs -> cs.hasPermission(3)) //permission
+                    .executes(this::locateSpecificRift)).requires(cs -> cs.hasPermission(3)) //permission
+                    .executes(this::locateAllRifts)));
     }
 
-    private int locateSpecificRift(CommandContext<CommandSourceStack> context)
-    {
-        int riftId = context.getArgument("riftId", int.class);
-        RiftInventory rift = RiftStorage.get(context.getSource().getLevel())
-                .getRift(riftId);
-        locateRiftById(context, riftId, rift);
+    private int locateSpecificRift(CommandContext<CommandSourceStack> context) {
+        if (!RiftStorage.isAvailable()) {
+            context.getSource().sendFailure(Component.literal("Failed to retrieve RiftStorage"));
+            return 0;
+        }
+        UUID id = context.getArgument("riftId", UUID.class);
+        RiftHolder holder = RiftStorage.get().getRift(id);
+        if (holder == null || !holder.isValid()) {
+            context.getSource().sendFailure(Component.literal(String.format("Couldn't find rift with id '%s'", id)));
+            return 0;
+        }
+        locateRiftById(context, id, holder.getInventory());
         return 0;
     }
 
-    private void locateRiftById(CommandContext<CommandSourceStack> context, int riftId, RiftInventory rift)
-    {
-        rift.locateListeners(pos ->
-                context.getSource().sendSuccess(Component.literal(String.format("Found rift with id %d at %s %s %s", riftId, pos.getX(), pos.getY(), pos.getZ())), true));
+    private void locateRiftById(CommandContext<CommandSourceStack> context, UUID riftId, RiftInventory rift) {
+        rift.locateListeners(context.getSource().getLevel(), (pos) -> context.getSource().sendSuccess(
+            Component.literal(String.format("Found rift with id '%s' at %s %s %s", riftId, pos.getX(), pos.getY(), pos.getZ()))
+                .setStyle(Style.EMPTY
+                    .withClickEvent(new ClickEvent(Action.RUN_COMMAND, String.format("/tp %s %s %s", pos.getX(), pos.getY(), pos.getZ())))),
+            true));
     }
 
-    private int locateAllRifts(CommandContext<CommandSourceStack> context)
-    {
-        RiftStorage.get(context.getSource().getLevel())
-                .walkExistingRifts((id, rift) -> locateRiftById(context, id, rift));
+    private int locateAllRifts(CommandContext<CommandSourceStack> context) {
+        RiftStorage.get().walkRifts((id, rift) -> locateRiftById(context, id, rift));
         return 0;
     }
 
-    public void gatherData(GatherDataEvent event)
-    {
+    public void gatherData(GatherDataEvent event) {
         Data.gatherData(event);
     }
 
-    public static ResourceLocation location(String path)
-    {
+    public static ResourceLocation location(String path) {
         return new ResourceLocation(MODID, path);
     }
 
-    public static class Data
-    {
-        public static void gatherData(GatherDataEvent event)
-        {
+    public static class Data {
+        public static void gatherData(GatherDataEvent event) {
             DataGenerator gen = event.getGenerator();
 
             gen.addProvider(event.includeServer(), new LootTableGen(gen));
             gen.addProvider(event.includeServer(), new BlockTagGens(gen, event.getExistingFileHelper()));
         }
 
-        private static class LootTableGen extends LootTableProvider implements DataProvider
-        {
-            public LootTableGen(DataGenerator gen)
-            {
+        private static class LootTableGen extends LootTableProvider implements DataProvider {
+            public LootTableGen(DataGenerator gen) {
                 super(gen);
             }
 
-            private final List<Pair<Supplier<Consumer<BiConsumer<ResourceLocation, LootTable.Builder>>>, LootContextParamSet>> tables = ImmutableList.of(
-                    Pair.of(BlockTables::new, LootContextParamSets.BLOCK)
-                    //Pair.of(FishingLootTables::new, LootParameterSets.FISHING),
-                    //Pair.of(ChestLootTables::new, LootParameterSets.CHEST),
-                    //Pair.of(EntityLootTables::new, LootParameterSets.ENTITY),
-                    //Pair.of(GiftLootTables::new, LootParameterSets.GIFT)
-            );
+            private final List<Pair<Supplier<Consumer<BiConsumer<ResourceLocation, LootTable.Builder>>>, LootContextParamSet>> tables = ImmutableList
+                .of(Pair.of(BlockTables::new, LootContextParamSets.BLOCK)
+                //Pair.of(FishingLootTables::new, LootParameterSets.FISHING),
+                //Pair.of(ChestLootTables::new, LootParameterSets.CHEST),
+                //Pair.of(EntityLootTables::new, LootParameterSets.ENTITY),
+                //Pair.of(GiftLootTables::new, LootParameterSets.GIFT)
+                );
 
             @Override
-            protected List<Pair<Supplier<Consumer<BiConsumer<ResourceLocation, LootTable.Builder>>>, LootContextParamSet>> getTables()
-            {
+            protected List<Pair<Supplier<Consumer<BiConsumer<ResourceLocation, LootTable.Builder>>>, LootContextParamSet>> getTables() {
                 return tables;
             }
 
             @Override
-            protected void validate(Map<ResourceLocation, LootTable> map, ValidationContext validationtracker)
-            {
+            protected void validate(Map<ResourceLocation, LootTable> map, ValidationContext validationtracker) {
                 map.forEach((p_218436_2_, p_218436_3_) -> {
                     LootTables.validate(validationtracker, p_218436_2_, p_218436_3_);
                 });
             }
 
-            public static class BlockTables extends BlockLoot
-            {
+            public static class BlockTables extends BlockLoot {
                 @Override
-                protected void addTables()
-                {
+                protected void addTables() {
                     this.dropSelf(GENERATOR.get());
                     this.dropSelf(DRIVER.get());
                     this.dropSelf(PROXY.get());
@@ -305,50 +340,34 @@ public class EnderRiftMod
                 }
 
                 @Override
-                protected Iterable<Block> getKnownBlocks()
-                {
+                protected Iterable<Block> getKnownBlocks() {
                     return ForgeRegistries.BLOCKS.getEntries().stream()
-                            .filter(e -> e.getKey().location().getNamespace().equals(EnderRiftMod.MODID))
-                            .map(Map.Entry::getValue)
-                            .collect(Collectors.toList());
+                        .filter(e -> e.getKey().location().getNamespace().equals(EnderRiftMod.MODID)).map(Map.Entry::getValue)
+                        .collect(Collectors.toList());
                 }
             }
         }
 
-        private static class BlockTagGens extends BlockTagsProvider implements DataProvider
-        {
-            public BlockTagGens(DataGenerator gen, ExistingFileHelper existingFileHelper)
-            {
+        private static class BlockTagGens extends BlockTagsProvider implements DataProvider {
+            public BlockTagGens(DataGenerator gen, ExistingFileHelper existingFileHelper) {
                 super(gen, MODID, existingFileHelper);
             }
 
             @Override
-            protected void addTags()
-            {
-                tag(BlockTags.MINEABLE_WITH_PICKAXE)
-                        .add(BROWSER.get())
-                        .add(CRAFTING_BROWSER.get())
-                        .add(INTERFACE.get())
-                        .add(PROXY.get())
-                        .add(DRIVER.get())
-                        .add(RIFT.get())
-                        .add(GENERATOR.get())
-                        .add(STRUCTURE_CORNER.get())
-                        .add(STRUCTURE_EDGE.get());
+            protected void addTags() {
+                tag(BlockTags.MINEABLE_WITH_PICKAXE).add(BROWSER.get()).add(CRAFTING_BROWSER.get()).add(INTERFACE.get()).add(PROXY.get())
+                    .add(DRIVER.get()).add(RIFT.get()).add(GENERATOR.get()).add(STRUCTURE_CORNER.get()).add(STRUCTURE_EDGE.get());
             }
         }
     }
 
-    public static class BlockItemNC extends BlockItem
-    {
-        public BlockItemNC(Block pBlock, Properties pProperties)
-        {
+    public static class BlockItemNC extends BlockItem {
+        public BlockItemNC(Block pBlock, Properties pProperties) {
             super(pBlock, pProperties);
         }
 
         @Override
-        public void fillItemCategory(CreativeModeTab pGroup, NonNullList<ItemStack> pItems)
-        {
+        public void fillItemCategory(CreativeModeTab pGroup, NonNullList<ItemStack> pItems) {
             // do nothing
         }
     }

--- a/src/main/java/dev/gigaherz/enderrift/EnderRiftMod.java
+++ b/src/main/java/dev/gigaherz/enderrift/EnderRiftMod.java
@@ -235,9 +235,17 @@ public class EnderRiftMod
 
     public void commandEvent(RegisterCommandsEvent event)
     {
-        event.getDispatcher().register(LiteralArgumentBuilder.<CommandSourceStack>literal("enderrift").then(Commands.literal("locate").then(Commands.argument("riftId", UuidArgument.uuid()).requires(cs -> cs.hasPermission(3)) // permission
-                .executes(this::locateSpecificRift)).requires(cs -> cs.hasPermission(3)) // permission
-                .executes(this::locateAllRifts)));
+        event.getDispatcher().register(
+                LiteralArgumentBuilder.<CommandSourceStack>literal("enderrift")
+                    .then(Commands.literal("locate")
+                            .then(Commands.argument("riftId", UuidArgument.uuid())
+                                    .requires(cs->cs.hasPermission(3)) //permission
+                                    .executes(this::locateSpecificRift)
+                            )
+                            .requires(cs->cs.hasPermission(3)) //permission
+                            .executes(this::locateAllRifts)
+                    )
+        );
     }
 
     private int locateSpecificRift(CommandContext<CommandSourceStack> context)
@@ -260,7 +268,10 @@ public class EnderRiftMod
 
     private void locateRiftById(CommandContext<CommandSourceStack> context, UUID riftId, RiftInventory rift)
     {
-        rift.locateListeners(context.getSource().getLevel(), (pos) -> context.getSource().sendSuccess(Component.literal(String.format("Found rift with id '%s' at %s %s %s", riftId, pos.getX(), pos.getY(), pos.getZ())).setStyle(Style.EMPTY.withClickEvent(new ClickEvent(Action.RUN_COMMAND, String.format("/tp %s %s %s", pos.getX(), pos.getY(), pos.getZ())))), true));
+        rift.locateListeners(context.getSource().getLevel(), (pos) -> 
+            context.getSource().sendSuccess(
+                    Component.literal(String.format("Found rift with id '%s' at %s %s %s", riftId, pos.getX(), pos.getY(), pos.getZ()))
+                    .setStyle(Style.EMPTY.withClickEvent(new ClickEvent(Action.RUN_COMMAND, String.format("/tp %s %s %s", pos.getX(), pos.getY(), pos.getZ())))), true));
     }
 
     private int locateAllRifts(CommandContext<CommandSourceStack> context)
@@ -296,11 +307,12 @@ public class EnderRiftMod
                 super(gen);
             }
 
-            private final List<Pair<Supplier<Consumer<BiConsumer<ResourceLocation, LootTable.Builder>>>, LootContextParamSet>> tables = ImmutableList.of(Pair.of(BlockTables::new, LootContextParamSets.BLOCK)
-            // Pair.of(FishingLootTables::new, LootParameterSets.FISHING),
-            // Pair.of(ChestLootTables::new, LootParameterSets.CHEST),
-            // Pair.of(EntityLootTables::new, LootParameterSets.ENTITY),
-            // Pair.of(GiftLootTables::new, LootParameterSets.GIFT)
+            private final List<Pair<Supplier<Consumer<BiConsumer<ResourceLocation, LootTable.Builder>>>, LootContextParamSet>> tables = ImmutableList.of(
+                Pair.of(BlockTables::new, LootContextParamSets.BLOCK)
+                // Pair.of(FishingLootTables::new, LootParameterSets.FISHING),
+                // Pair.of(ChestLootTables::new, LootParameterSets.CHEST),
+                // Pair.of(EntityLootTables::new, LootParameterSets.ENTITY),
+                // Pair.of(GiftLootTables::new, LootParameterSets.GIFT)
             );
 
             @Override
@@ -334,7 +346,10 @@ public class EnderRiftMod
                 @Override
                 protected Iterable<Block> getKnownBlocks()
                 {
-                    return ForgeRegistries.BLOCKS.getEntries().stream().filter(e -> e.getKey().location().getNamespace().equals(EnderRiftMod.MODID)).map(Map.Entry::getValue).collect(Collectors.toList());
+                    return ForgeRegistries.BLOCKS.getEntries().stream()
+                            .filter(e -> e.getKey().location().getNamespace().equals(EnderRiftMod.MODID))
+                            .map(Map.Entry::getValue)
+                            .collect(Collectors.toList());
                 }
             }
         }
@@ -349,7 +364,16 @@ public class EnderRiftMod
             @Override
             protected void addTags()
             {
-                tag(BlockTags.MINEABLE_WITH_PICKAXE).add(BROWSER.get()).add(CRAFTING_BROWSER.get()).add(INTERFACE.get()).add(PROXY.get()).add(DRIVER.get()).add(RIFT.get()).add(GENERATOR.get()).add(STRUCTURE_CORNER.get()).add(STRUCTURE_EDGE.get());
+                tag(BlockTags.MINEABLE_WITH_PICKAXE)
+                    .add(BROWSER.get())
+                    .add(CRAFTING_BROWSER.get())
+                    .add(INTERFACE.get())
+                    .add(PROXY.get())
+                    .add(DRIVER.get())
+                    .add(RIFT.get())
+                    .add(GENERATOR.get())
+                    .add(STRUCTURE_CORNER.get())
+                    .add(STRUCTURE_EDGE.get());
             }
         }
     }

--- a/src/main/java/dev/gigaherz/enderrift/automation/browser/AbstractBrowserContainer.java
+++ b/src/main/java/dev/gigaherz/enderrift/automation/browser/AbstractBrowserContainer.java
@@ -395,7 +395,7 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
                 {
                     int amount = clickedButton == 0 
                             ? existing.getMaxStackSize() 
-                            : Math.min(existing.getCount() / 2, existing.getMaxStackSize() / 2);
+                            : Math.min(existing.getCount(), existing.getMaxStackSize()) / 2;
 
                     ItemStack extracted = extractItemsSided(parent, existing, existingSize, amount, false);
                     if (extracted.getCount() > 0)
@@ -418,9 +418,9 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
             }
             else if (mode == ClickType.QUICK_MOVE && existingSize > 0)
             {
-                int amount = existing.getMaxStackSize();
-                if (clickedButton != 0 && amount > 1)
-                    amount /= 2;
+                int amount = clickedButton == 0 
+                        ? existing.getMaxStackSize() 
+                        : Math.min(existing.getCount(), existing.getMaxStackSize()) / 2;
 
                 if (amount == 0)
                     return;

--- a/src/main/java/dev/gigaherz/enderrift/automation/browser/AbstractBrowserContainer.java
+++ b/src/main/java/dev/gigaherz/enderrift/automation/browser/AbstractBrowserContainer.java
@@ -31,847 +31,847 @@ import java.util.Objects;
 
 public class AbstractBrowserContainer extends AbstractContainerMenu
 {
-	protected final static int LEFT = 8;
-	protected final static int TOP = 18;
-	protected final static int SLOT_WIDTH = 18;
-	protected final static int SLOT_HEIGHT = 18;
-
-	protected final static int SCROLL_ROWS = 3;
-	protected final static int SCROLL_COLUMNS = 9;
-	protected final static int SCROLL_SLOTS = SCROLL_ROWS * SCROLL_COLUMNS;
-
-	protected final static int PLAYER_ROWS = 4;
-	protected final static int PLAYER_COLUMNS = 9;
-	protected final static int PLAYER_SLOTS = PLAYER_ROWS * PLAYER_COLUMNS;
-
-	private NonNullList<ItemStack> currentStacks = NonNullList.create();
-	private final Player player;
-	private int prevChangeCount;
-	private ItemStack stackInCursor = ItemStack.EMPTY;
-
-	@Nullable
-	protected BrowserBlockEntity tile;
-
-	public final IItemHandlerModifiable scrollInventory;
-	public int scroll;
-	public SortMode sortMode = SortMode.STACK_SIZE;
-	public String filterText = "";
-
-	private DataSlot isLowOnPower = new DataSlot()
-	{
-		boolean value = false;
-
-		@Override
-		public int get()
-		{
-			return (isClient() ? value : tile.isLowOnPower()) ? 1 : 0;
-		}
-
-		@Override
-		public void set(int value)
-		{
-			this.value = value != 0;
-		}
-	};
-
-	public final boolean isClient()
-	{
-		return tile == null;
-	}
-
-	public ClientScrollInventory getClient()
-	{
-		if (!isClient())
-			throw new IllegalStateException("Attempted to get client inventory on the server");
-		return (ClientScrollInventory) scrollInventory;
-	}
-
-	public ServerScrollInventory getServer()
-	{
-		if (isClient())
-			throw new IllegalStateException("Attempted to get server inventory on the client");
-		return (ServerScrollInventory) scrollInventory;
-	}
-
-	protected AbstractBrowserContainer(MenuType<? extends AbstractBrowserContainer> type, int id, @Nullable BrowserBlockEntity tileEntity, Inventory playerInventory)
-	{
-		super(type, id);
-
-		this.player = playerInventory.player;
-		boolean isClient = player.level.isClientSide;
-
-		if (isClient)
-		{
-			this.tile = null;
-			scrollInventory = new ClientScrollInventory();
-		} else
-		{
-			this.tile = Objects.requireNonNull(tileEntity);
-			scrollInventory = new ServerScrollInventory(tile);
-		}
-
-		for (int y = 0; y < SCROLL_ROWS; y++)
-		{
-			for (int x = 0; x < SCROLL_COLUMNS; x++)
-			{
-				addSlot(new SlotFake(scrollInventory, x + y * SCROLL_COLUMNS, LEFT + x * SLOT_WIDTH, TOP + y * SLOT_HEIGHT));
-			}
-		}
-
-		bindPlayerInventory(playerInventory);
-
-		addDataSlot(isLowOnPower);
-	}
-
-	protected void bindPlayerInventory(Inventory playerInventory)
-	{
-		bindPlayerInventory(playerInventory, TOP + SCROLL_ROWS * SLOT_HEIGHT + 14);
-	}
-
-	protected void bindPlayerInventory(Inventory playerInventory, int top)
-	{
-		for (int y = 0; y < 3; y++)
-		{
-			for (int x = 0; x < 9; x++)
-			{
-				addSlot(new Slot(playerInventory, x + y * 9 + 9, LEFT + x * SLOT_WIDTH, top + y * SLOT_HEIGHT));
-			}
-		}
-
-		top += 3 * SLOT_HEIGHT + 4;
-		for (int x = 0; x < 9; x++)
-		{
-			addSlot(new Slot(playerInventory, x, LEFT + x * SLOT_WIDTH, top));
-		}
-	}
-
-	@Override
-	public boolean stillValid(Player player)
-	{
-		return true;
-	}
-
-	@Override
-	public void broadcastChanges()
-	{
-		if (isClient())
-			return;
-
-		ServerScrollInventory serverInv = getServer();
-		if (prevChangeCount != tile.getChangeCount())
-		{
-			serverInv.refresh();
-			prevChangeCount = tile.getChangeCount();
-		}
-
-		int oldLength = currentStacks.size();
-		int newLength;
-		List<Integer> indicesChanged = Lists.newArrayList();
-		List<ItemStack> stacksChanged = Lists.newArrayList();
-
-		newLength = serverInv.getRealSizeInventory();
-		if (newLength != oldLength)
-		{
-			changeSize(oldLength, newLength);
-		}
-
-		for (int i = 0; i < newLength; ++i)
-		{
-			ItemStack newStack = serverInv.getStack(i);
-			ItemStack current = currentStacks.get(i);
-
-			if (!ItemStack.matches(current, newStack))
-			{
-				current = newStack.copy();
-				currentStacks.set(i, current);
-
-				indicesChanged.add(i);
-				stacksChanged.add(current);
-			}
-		}
-
-		for (int i = SCROLL_SLOTS; i < this.slots.size(); ++i)
-		{
-			ItemStack inSlot = slots.get(i).getItem();
-			ItemStack inCache = lastSlots.get(i);
-
-			if (!ItemStack.matches(inCache, inSlot))
-			{
-				inCache = inSlot.copy();
-				this.lastSlots.set(i, inCache);
-
-				for (ContainerListener crafter : this.containerListeners)
-				{
-					crafter.slotChanged(this, i, inCache);
-				}
-			}
-		}
-
-		if (player instanceof ServerPlayer crafter)
-		{
-			if (newLength != oldLength || indicesChanged.size() > 0)
-			{
-				EnderRiftMod.CHANNEL.sendTo(new SendSlotChanges(containerId, newLength, indicesChanged, stacksChanged), crafter.connection.getConnection(), NetworkDirection.PLAY_TO_CLIENT);
-			}
-
-			ItemStack newStack = getCarried();
-
-			if (!ItemStack.matches(stackInCursor, newStack))
-			{
-				sendStackInCursor(crafter, newStack);
-			}
-		}
-
-		if (newLength != oldLength || indicesChanged.size() > 0)
-		{
-			serverInv.resetVisible();
-		}
-	}
-
-	private void changeSize(int oldLength, int newLength)
-	{
-		NonNullList<ItemStack> oldStacks = currentStacks;
-		currentStacks = NonNullList.withSize(newLength, ItemStack.EMPTY);
-		for (int i = 0; i < Math.min(newLength, oldLength); i++)
-		{
-			currentStacks.set(i, oldStacks.get(i));
-		}
-	}
-
-	private void sendStackInCursor(ServerPlayer player, ItemStack newStack)
-	{
-		stackInCursor = newStack.copy();
-
-		player.connection.send(new ClientboundContainerSetSlotPacket(-1, incrementStateId(), -1, newStack));
-	}
-
-	public void slotsChanged(int slotCount, List<Integer> indices, List<ItemStack> stacks)
-	{
-		if (slotCount != currentStacks.size())
-		{
-			changeSize(currentStacks.size(), slotCount);
-		}
-
-		for (int i = 0; i < indices.size(); i++)
-		{
-			int slot = indices.get(i);
-			ItemStack stack = stacks.get(i);
-
-			currentStacks.set(slot, stack);
-		}
-
-		ClientScrollInventory clientInv = getClient();
-		clientInv.setArray(currentStacks);
-
-		setVisibleSlots(clientInv.getIndices());
-	}
-
-	@Override
-	public void initializeContents(int p_182411_, List<ItemStack> p_182412_, ItemStack p_182413_)
-	{
-		super.initializeContents(p_182411_, List.of(), p_182413_);
-	}
-
-	public void setVisibleSlots(int[] visible)
-	{
-		if (isClient())
-		{
-			EnderRiftMod.CHANNEL.sendToServer(new SetVisibleSlots(containerId, visible));
-		} else
-		{
-			getServer().setVisible(visible);
-		}
-	}
-
-	public void setScrollPos(int scroll)
-	{
-		this.scroll = scroll;
-
-		setVisibleSlots(getClient().getIndices());
-	}
-
-	public void setSortMode(SortMode sortMode)
-	{
-		this.sortMode = sortMode;
-		this.scroll = 0;
-
-		ClientScrollInventory clientInv = getClient();
-		clientInv.setArray(currentStacks);
-
-		setVisibleSlots(clientInv.getIndices());
-	}
-
-	public void setFilterText(String text)
-	{
-		this.filterText = text.toLowerCase();
-		this.scroll = 0;
-
-		ClientScrollInventory clientInv = getClient();
-		clientInv.setArray(currentStacks);
-
-		setVisibleSlots(clientInv.getIndices());
-	}
-
-	@Override
-	public void setItem(int slotID, int stateId, ItemStack stack)
-	{
-		super.setItem(slotID, stateId, stack);
-	}
-
-	@Override
-	public void clicked(int slotId, int clickedButton, ClickType mode, Player playerIn)
-	{
-		if (slotId >= 0 && slotId < SCROLL_SLOTS)
-		{
-			IItemHandler parent = getTileInventory();
-
-			Slot slot = this.slots.get(slotId);
-			ItemStack existing = slot.getItem();
-			int existingSize = isClient() ? getClient().getStackSizeForSlot(slotId) : existing.getCount();
-
-			if (mode == ClickType.PICKUP)
-			{
-				ItemStack dropping = getCarried();
-
-				if (dropping.getCount() > 0)
-				{
-					if (clickedButton == 0)
-					{
-						ItemStack remaining = insertItemsSided(parent, dropping);
-						if (remaining.getCount() > 0)
-						{
-							if (dropping.getCount() != remaining.getCount())
-								markTileDirty();
-
-							if (player instanceof ServerPlayer crafter)
-							{
-								sendStackInCursor(crafter, remaining);
-							}
-						} else
-						{
-							markTileDirty();
-						}
-						setCarried(remaining);
-					} else
-					{
-						int amount = 1;
-
-						ItemStack push = dropping.copy();
-						push.setCount(amount);
-						ItemStack remaining = insertItemsSided(parent, push);
-
-						dropping.shrink(push.getCount());
-
-						if (remaining.getCount() > 0)
-						{
-							if (push.getCount() != remaining.getCount())
-								markTileDirty();
-							dropping.grow(remaining.getCount());
-
-							if (player instanceof ServerPlayer crafter)
-							{
-								sendStackInCursor(crafter, remaining);
-							}
-						} else
-						{
-							markTileDirty();
-						}
-
-						if (dropping.getCount() <= 0)
-							dropping = ItemStack.EMPTY;
-
-						setCarried(dropping);
-					}
-				} else if (existingSize > 0)
-				{
-					int amount = clickedButton == 0 ? existing.getMaxStackSize() : existing.getMaxStackSize() / 2;
-
-					ItemStack extracted = extractItemsSided(parent, existing, existingSize, amount, false);
-					if (extracted.getCount() > 0)
-					{
-						markTileDirty();
-					} else
-					{
-
-						if (player instanceof ServerPlayer crafter)
-						{
-							sendStackInCursor(crafter, extracted);
-						}
-					}
-					setCarried(extracted);
-				}
-
-				broadcastChanges();
-				return;
-			} else if (mode == ClickType.QUICK_MOVE && existingSize > 0)
-			{
-				int amount = existing.getMaxStackSize();
-				if (clickedButton != 0 && amount > 1)
-					amount /= 2;
-
-				if (amount == 0)
-					return;
-
-				ItemStack remaining = simulateAddToPlayer(existing, amount);
-
-				if (remaining.getCount() > 0)
-					amount -= remaining.getCount();
-
-				if (amount > 0)
-				{
-					ItemStack finalExtract = extractItemsSided(parent, existing, existingSize, amount, false);
-
-					if (finalExtract.getCount() > 0)
-					{
-						addToPlayer(finalExtract);
-
-						markTileDirty();
-						broadcastChanges();
-					}
-				}
-			}
-
-			if (mode != ClickType.CLONE)
-				return;
-		}
-
-		super.clicked(slotId, clickedButton, mode, playerIn);
-	}
-
-	@Nullable
-	private IItemHandler getTileInventory()
-	{
-		return isClient() ? null : tile.getCombinedInventory();
-	}
-
-	private void markTileDirty()
-	{
-		if (!isClient())
-			tile.setChanged();
-	}
-
-	private ItemStack extractItemsSided(@Nullable IItemHandler parent, ItemStack existing, int existingSize, int amount, boolean simulate)
-	{
-		if (isClient() || parent == null)
-		{
-			var copy = existing.copy();
-			copy.setCount(Math.min(existingSize, amount));
-			return copy;
-		}
-		return AutomationHelper.extractItems(parent, existing, amount, simulate);
-	}
-
-	private ItemStack insertItemsSided(@Nullable IItemHandler parent, ItemStack dropping)
-	{
-		if (isClient() || parent == null)
-			return ItemStack.EMPTY;
-		return AutomationHelper.insertItems(parent, dropping);
-	}
-
-	private ItemStack simulateAddToPlayer(ItemStack stack, int amount)
-	{
-		int startIndex = SCROLL_SLOTS;
-		int endIndex = startIndex + PLAYER_SLOTS;
-
-		ItemStack stackCopy = stack.copy();
-		stackCopy.setCount(amount);
-
-		if (!this.simulateInsertStack(stackCopy, startIndex, endIndex))
-		{
-			return stackCopy;
-		}
-
-		if (stackCopy.getCount() <= 0)
-		{
-			return ItemStack.EMPTY;
-		}
-
-		return stackCopy;
-	}
-
-	protected boolean simulateInsertStack(ItemStack stack, int startIndex, int endIndex)
-	{
-		boolean canInsert = false;
-
-		if (stack.isStackable())
-		{
-			for (int i = startIndex; stack.getCount() > 0 && i < endIndex; i++)
-			{
-				Slot slot = this.slots.get(i);
-				ItemStack stackInSlot = slot.getItem();
-
-				if (stackInSlot.getCount() < stackInSlot.getMaxStackSize() && ItemStack.isSame(stackInSlot, stack) && ItemStack.tagMatches(stack, stackInSlot))
-				{
-					int j = stackInSlot.getCount() + stack.getCount();
-
-					if (j <= stack.getMaxStackSize())
-					{
-						stack.setCount(0);
-						canInsert = true;
-					} else
-					{
-						stack.shrink(stack.getMaxStackSize() - stackInSlot.getCount());
-						canInsert = true;
-					}
-				}
-			}
-		}
-
-		if (stack.getCount() > 0)
-		{
-			for (int i = startIndex; i < endIndex; i++)
-			{
-				Slot slot = this.slots.get(i);
-				ItemStack stackInSlot = slot.getItem();
-
-				if (stackInSlot.getCount() <= 0 && slot.mayPlace(stack))
-				{
-					stack.setCount(0);
-					canInsert = true;
-					break;
-				}
-			}
-		}
-
-		return canInsert;
-	}
-
-	public ItemStack addToPlayer(ItemStack stack)
-	{
-		int startIndex = SCROLL_SLOTS;
-		int endIndex = startIndex + PLAYER_SLOTS;
-
-		ItemStack stackCopy = stack.copy();
-
-		if (!this.moveItemStackTo(stackCopy, startIndex, endIndex, false))
-		{
-			return stackCopy;
-		}
-
-		if (stackCopy.getCount() <= 0)
-		{
-			return ItemStack.EMPTY;
-		}
-
-		return stackCopy;
-	}
-
-	@Override
-	public ItemStack quickMoveStack(Player player, int slotIndex)
-	{
-		Slot slot = this.slots.get(slotIndex);
-
-		if (slot == null || !slot.hasItem())
-		{
-			return ItemStack.EMPTY;
-		}
-
-		if (slotIndex < SCROLL_SLOTS)
-		{
-			// Shouldn't even happen, handled above.
-			return ItemStack.EMPTY;
-		} else
-		{
-			ItemStack stack = slot.getItem();
-			ItemStack stackCopy = stack.copy();
-
-			ItemStack remaining = insertItemsSided(getTileInventory(), stack);
-			if (remaining.getCount() > 0)
-			{
-				if (player instanceof ContainerListener)
-				{
-					((ContainerListener) player).slotChanged(this, slotIndex, remaining);
-				}
-
-				if (remaining.getCount() == stackCopy.getCount())
-				{
-					return ItemStack.EMPTY;
-				}
-
-				markTileDirty();
-				stack.setCount(remaining.getCount());
-				slot.setChanged();
-			} else
-			{
-				markTileDirty();
-				stack.setCount(0);
-				slot.set(ItemStack.EMPTY);
-			}
-
-			slot.onTake(player, stack);
-			return stackCopy;
-		}
-	}
-
-	public int getActualSlotCount()
-	{
-		return scrollInventory.getSlots();
-	}
-
-	public boolean isLowOnPower()
-	{
-		return isLowOnPower.get() != 0;
-	}
-
-	public static class ServerScrollInventory implements IItemHandlerModifiable
-	{
-		final BrowserBlockEntity tile;
-		final List<ItemStack> slots = Lists.newArrayList();
-		private int[] visible = new int[0];
-
-		public ServerScrollInventory(BrowserBlockEntity tile)
-		{
-			this.tile = tile;
-		}
-
-		public void setVisible(int[] visible)
-		{
-			this.visible = visible;
-		}
-
-		public void resetVisible()
-		{
-			visible = new int[0];
-		}
-
-		public void refresh()
-		{
-			IItemHandler inv = tile.getCombinedInventory();
-
-			final List<ItemStack> slotsSeen = Lists.newArrayList();
-
-			slots.clear();
-
-			if (inv == null)
-				return;
-
-			int invSlots = inv.getSlots();
-			for (int j = 0; j < invSlots; j++)
-			{
-				ItemStack invStack = inv.getStackInSlot(j);
-				if (invStack.getCount() <= 0)
-					continue;
-
-				boolean found = false;
-
-				for (ItemStack cachedStack : slotsSeen)
-				{
-					if (ItemStack.isSame(cachedStack, invStack) && ItemStack.tagMatches(cachedStack, invStack))
-					{
-						cachedStack.grow(invStack.getCount());
-						found = true;
-						break;
-					}
-				}
-
-				if (!found)
-				{
-					ItemStack stack = invStack.copy();
-					slotsSeen.add(stack);
-
-					slots.add(stack);
-				}
-			}
-		}
-
-		public int getRealSizeInventory()
-		{
-			return slots.size();
-		}
-
-		@Override
-		public int getSlots()
-		{
-			return visible.length;
-		}
-
-		@Override
-		public ItemStack getStackInSlot(int index)
-		{
-			if (index >= visible.length)
-				return ItemStack.EMPTY;
-			int i = visible[index];
-			if (i >= slots.size())
-				return ItemStack.EMPTY;
-			return slots.get(visible[index]);
-		}
-
-		public ItemStack getStack(int index)
-		{
-			return slots.get(index);
-		}
-
-		@Override
-		public ItemStack insertItem(int slot, ItemStack stack, boolean simulate)
-		{
-			return ItemStack.EMPTY;
-		}
-
-		@Override
-		public ItemStack extractItem(int slot, int amount, boolean simulate)
-		{
-			return ItemStack.EMPTY;
-		}
-
-		@Override
-		public int getSlotLimit(int slot)
-		{
-			return 64;
-		}
-
-		@Override
-		public boolean isItemValid(int slot, @Nonnull ItemStack stack)
-		{
-			return true;
-		}
-
-		@Override
-		public void setStackInSlot(int slot, ItemStack stack)
-		{
-		}
-	}
-
-	public class ClientScrollInventory implements IItemHandlerModifiable
-	{
-		private int[] indices;
-		private NonNullList<ItemStack> stacks;
-
-		public ClientScrollInventory()
-		{
-		}
-
-		public void setArray(final NonNullList<ItemStack> stacks)
-		{
-			this.stacks = stacks;
-
-			final List<Integer> indices = Lists.newArrayList();
-
-			final List<Component> itemData = Lists.newArrayList();
-
-			int indexx = 0;
-			for (ItemStack invStack : stacks)
-			{
-				ItemStack stack = invStack.copy();
-
-				boolean matchesSearch = true;
-				if (!Strings.isNullOrEmpty(filterText))
-				{
-					itemData.clear();
-					Item item = invStack.getItem();
-					itemData.add(stack.getHoverName());
-					itemData.add(Component.literal(ForgeRegistries.ITEMS.getKey(item).toString()));
-					item.appendHoverText(stack, player.level, itemData, TooltipFlag.Default.NORMAL);
-					matchesSearch = false;
-					for (Component s : itemData)
-					{
-						if (StringUtils.containsIgnoreCase(s.getString(), filterText))
-						{
-							matchesSearch = true;
-							break;
-						}
-					}
-				}
-
-				if (matchesSearch)
-				{
-					indices.add(indexx);
-				}
-				indexx++;
-			}
-
-			if (sortMode != null)
-			{
-				switch (sortMode)
-				{
-				case ALPHABETIC:
-					indices.sort((ia, ib) -> {
-						ItemStack a = stacks.get(ia);
-						ItemStack b = stacks.get(ib);
-						return a.getHoverName().getString().compareToIgnoreCase(b.getHoverName().getString());
-					});
-					break;
-				case STACK_SIZE:
-					indices.sort((ia, ib) -> {
-						ItemStack a = stacks.get(ia);
-						ItemStack b = stacks.get(ib);
-						int diff = a.getCount() - b.getCount();
-						if (diff > 0)
-							return -1;
-						if (diff < 0)
-							return 1;
-						return a.getHoverName().getString().compareToIgnoreCase(b.getHoverName().getString());
-					});
-					break;
-				}
-			}
-
-			this.indices = new int[indices.size()];
-			for (int i = 0; i < this.indices.length; i++)
-			{
-				this.indices[i] = indices.get(i);
-			}
-		}
-
-		@Override
-		public int getSlots()
-		{
-			return indices.length;
-		}
-
-		@Override
-		public ItemStack getStackInSlot(int slot)
-		{
-			if ((slot + scroll) >= indices.length)
-				return ItemStack.EMPTY;
-			ItemStack stack = stacks.get(indices[slot + scroll]);
-			stack = stack.copy();
-			stack.setCount(1);
-			return stack;
-		}
-
-		@Override
-		public ItemStack insertItem(int slot, ItemStack stack, boolean simulate)
-		{
-			return ItemStack.EMPTY;
-		}
-
-		@Override
-		public ItemStack extractItem(int slot, int amount, boolean simulate)
-		{
-			return ItemStack.EMPTY;
-		}
-
-		@Override
-		public int getSlotLimit(int slot)
-		{
-			return 64;
-		}
-
-		@Override
-		public boolean isItemValid(int slot, @Nonnull ItemStack stack)
-		{
-			return true;
-		}
-
-		@Override
-		public void setStackInSlot(int slot, ItemStack stack)
-		{
-			if ((slot + scroll) < indices.length)
-				stacks.set(indices[slot + scroll], stack);
-		}
-
-		public int getStackSizeForSlot(int slot)
-		{
-			if ((slot + scroll) >= indices.length)
-				return 0;
-			return stacks.get(indices[slot + scroll]).getCount();
-		}
-
-		public int[] getIndices()
-		{
-			int from = Math.max(0, Math.min(scroll, indices.length - 1));
-			int to = Math.min(from + SCROLL_SLOTS, indices.length);
-			return Arrays.copyOfRange(indices, from, to);
-		}
-	}
+    protected final static int LEFT = 8;
+    protected final static int TOP = 18;
+    protected final static int SLOT_WIDTH = 18;
+    protected final static int SLOT_HEIGHT = 18;
+
+    protected final static int SCROLL_ROWS = 3;
+    protected final static int SCROLL_COLUMNS = 9;
+    protected final static int SCROLL_SLOTS = SCROLL_ROWS * SCROLL_COLUMNS;
+
+    protected final static int PLAYER_ROWS = 4;
+    protected final static int PLAYER_COLUMNS = 9;
+    protected final static int PLAYER_SLOTS = PLAYER_ROWS * PLAYER_COLUMNS;
+
+    private NonNullList<ItemStack> currentStacks = NonNullList.create();
+    private final Player player;
+    private int prevChangeCount;
+    private ItemStack stackInCursor = ItemStack.EMPTY;
+
+    @Nullable
+    protected BrowserBlockEntity tile;
+
+    public final IItemHandlerModifiable scrollInventory;
+    public int scroll;
+    public SortMode sortMode = SortMode.STACK_SIZE;
+    public String filterText = "";
+
+    private DataSlot isLowOnPower = new DataSlot()
+    {
+        boolean value = false;
+
+        @Override
+        public int get()
+        {
+            return (isClient() ? value : tile.isLowOnPower()) ? 1 : 0;
+        }
+
+        @Override
+        public void set(int value)
+        {
+            this.value = value != 0;
+        }
+    };
+
+    public final boolean isClient()
+    {
+        return tile == null;
+    }
+
+    public ClientScrollInventory getClient()
+    {
+        if (!isClient())
+            throw new IllegalStateException("Attempted to get client inventory on the server");
+        return (ClientScrollInventory) scrollInventory;
+    }
+
+    public ServerScrollInventory getServer()
+    {
+        if (isClient())
+            throw new IllegalStateException("Attempted to get server inventory on the client");
+        return (ServerScrollInventory) scrollInventory;
+    }
+
+    protected AbstractBrowserContainer(MenuType<? extends AbstractBrowserContainer> type, int id, @Nullable BrowserBlockEntity tileEntity, Inventory playerInventory)
+    {
+        super(type, id);
+
+        this.player = playerInventory.player;
+        boolean isClient = player.level.isClientSide;
+
+        if (isClient)
+        {
+            this.tile = null;
+            scrollInventory = new ClientScrollInventory();
+        } else
+        {
+            this.tile = Objects.requireNonNull(tileEntity);
+            scrollInventory = new ServerScrollInventory(tile);
+        }
+
+        for (int y = 0; y < SCROLL_ROWS; y++)
+        {
+            for (int x = 0; x < SCROLL_COLUMNS; x++)
+            {
+                addSlot(new SlotFake(scrollInventory, x + y * SCROLL_COLUMNS, LEFT + x * SLOT_WIDTH, TOP + y * SLOT_HEIGHT));
+            }
+        }
+
+        bindPlayerInventory(playerInventory);
+
+        addDataSlot(isLowOnPower);
+    }
+
+    protected void bindPlayerInventory(Inventory playerInventory)
+    {
+        bindPlayerInventory(playerInventory, TOP + SCROLL_ROWS * SLOT_HEIGHT + 14);
+    }
+
+    protected void bindPlayerInventory(Inventory playerInventory, int top)
+    {
+        for (int y = 0; y < 3; y++)
+        {
+            for (int x = 0; x < 9; x++)
+            {
+                addSlot(new Slot(playerInventory, x + y * 9 + 9, LEFT + x * SLOT_WIDTH, top + y * SLOT_HEIGHT));
+            }
+        }
+
+        top += 3 * SLOT_HEIGHT + 4;
+        for (int x = 0; x < 9; x++)
+        {
+            addSlot(new Slot(playerInventory, x, LEFT + x * SLOT_WIDTH, top));
+        }
+    }
+
+    @Override
+    public boolean stillValid(Player player)
+    {
+        return true;
+    }
+
+    @Override
+    public void broadcastChanges()
+    {
+        if (isClient())
+            return;
+
+        ServerScrollInventory serverInv = getServer();
+        if (prevChangeCount != tile.getChangeCount())
+        {
+            serverInv.refresh();
+            prevChangeCount = tile.getChangeCount();
+        }
+
+        int oldLength = currentStacks.size();
+        int newLength;
+        List<Integer> indicesChanged = Lists.newArrayList();
+        List<ItemStack> stacksChanged = Lists.newArrayList();
+
+        newLength = serverInv.getRealSizeInventory();
+        if (newLength != oldLength)
+        {
+            changeSize(oldLength, newLength);
+        }
+
+        for (int i = 0; i < newLength; ++i)
+        {
+            ItemStack newStack = serverInv.getStack(i);
+            ItemStack current = currentStacks.get(i);
+
+            if (!ItemStack.matches(current, newStack))
+            {
+                current = newStack.copy();
+                currentStacks.set(i, current);
+
+                indicesChanged.add(i);
+                stacksChanged.add(current);
+            }
+        }
+
+        for (int i = SCROLL_SLOTS; i < this.slots.size(); ++i)
+        {
+            ItemStack inSlot = slots.get(i).getItem();
+            ItemStack inCache = lastSlots.get(i);
+
+            if (!ItemStack.matches(inCache, inSlot))
+            {
+                inCache = inSlot.copy();
+                this.lastSlots.set(i, inCache);
+
+                for (ContainerListener crafter : this.containerListeners)
+                {
+                    crafter.slotChanged(this, i, inCache);
+                }
+            }
+        }
+
+        if (player instanceof ServerPlayer crafter)
+        {
+            if (newLength != oldLength || indicesChanged.size() > 0)
+            {
+                EnderRiftMod.CHANNEL.sendTo(new SendSlotChanges(containerId, newLength, indicesChanged, stacksChanged), crafter.connection.getConnection(), NetworkDirection.PLAY_TO_CLIENT);
+            }
+
+            ItemStack newStack = getCarried();
+
+            if (!ItemStack.matches(stackInCursor, newStack))
+            {
+                sendStackInCursor(crafter, newStack);
+            }
+        }
+
+        if (newLength != oldLength || indicesChanged.size() > 0)
+        {
+            serverInv.resetVisible();
+        }
+    }
+
+    private void changeSize(int oldLength, int newLength)
+    {
+        NonNullList<ItemStack> oldStacks = currentStacks;
+        currentStacks = NonNullList.withSize(newLength, ItemStack.EMPTY);
+        for (int i = 0; i < Math.min(newLength, oldLength); i++)
+        {
+            currentStacks.set(i, oldStacks.get(i));
+        }
+    }
+
+    private void sendStackInCursor(ServerPlayer player, ItemStack newStack)
+    {
+        stackInCursor = newStack.copy();
+
+        player.connection.send(new ClientboundContainerSetSlotPacket(-1, incrementStateId(), -1, newStack));
+    }
+
+    public void slotsChanged(int slotCount, List<Integer> indices, List<ItemStack> stacks)
+    {
+        if (slotCount != currentStacks.size())
+        {
+            changeSize(currentStacks.size(), slotCount);
+        }
+
+        for (int i = 0; i < indices.size(); i++)
+        {
+            int slot = indices.get(i);
+            ItemStack stack = stacks.get(i);
+
+            currentStacks.set(slot, stack);
+        }
+
+        ClientScrollInventory clientInv = getClient();
+        clientInv.setArray(currentStacks);
+
+        setVisibleSlots(clientInv.getIndices());
+    }
+
+    @Override
+    public void initializeContents(int p_182411_, List<ItemStack> p_182412_, ItemStack p_182413_)
+    {
+        super.initializeContents(p_182411_, List.of(), p_182413_);
+    }
+
+    public void setVisibleSlots(int[] visible)
+    {
+        if (isClient())
+        {
+            EnderRiftMod.CHANNEL.sendToServer(new SetVisibleSlots(containerId, visible));
+        } else
+        {
+            getServer().setVisible(visible);
+        }
+    }
+
+    public void setScrollPos(int scroll)
+    {
+        this.scroll = scroll;
+
+        setVisibleSlots(getClient().getIndices());
+    }
+
+    public void setSortMode(SortMode sortMode)
+    {
+        this.sortMode = sortMode;
+        this.scroll = 0;
+
+        ClientScrollInventory clientInv = getClient();
+        clientInv.setArray(currentStacks);
+
+        setVisibleSlots(clientInv.getIndices());
+    }
+
+    public void setFilterText(String text)
+    {
+        this.filterText = text.toLowerCase();
+        this.scroll = 0;
+
+        ClientScrollInventory clientInv = getClient();
+        clientInv.setArray(currentStacks);
+
+        setVisibleSlots(clientInv.getIndices());
+    }
+
+    @Override
+    public void setItem(int slotID, int stateId, ItemStack stack)
+    {
+        super.setItem(slotID, stateId, stack);
+    }
+
+    @Override
+    public void clicked(int slotId, int clickedButton, ClickType mode, Player playerIn)
+    {
+        if (slotId >= 0 && slotId < SCROLL_SLOTS)
+        {
+            IItemHandler parent = getTileInventory();
+
+            Slot slot = this.slots.get(slotId);
+            ItemStack existing = slot.getItem();
+            int existingSize = isClient() ? getClient().getStackSizeForSlot(slotId) : existing.getCount();
+
+            if (mode == ClickType.PICKUP)
+            {
+                ItemStack dropping = getCarried();
+
+                if (dropping.getCount() > 0)
+                {
+                    if (clickedButton == 0)
+                    {
+                        ItemStack remaining = insertItemsSided(parent, dropping);
+                        if (remaining.getCount() > 0)
+                        {
+                            if (dropping.getCount() != remaining.getCount())
+                                markTileDirty();
+
+                            if (player instanceof ServerPlayer crafter)
+                            {
+                                sendStackInCursor(crafter, remaining);
+                            }
+                        } else
+                        {
+                            markTileDirty();
+                        }
+                        setCarried(remaining);
+                    } else
+                    {
+                        int amount = 1;
+
+                        ItemStack push = dropping.copy();
+                        push.setCount(amount);
+                        ItemStack remaining = insertItemsSided(parent, push);
+
+                        dropping.shrink(push.getCount());
+
+                        if (remaining.getCount() > 0)
+                        {
+                            if (push.getCount() != remaining.getCount())
+                                markTileDirty();
+                            dropping.grow(remaining.getCount());
+
+                            if (player instanceof ServerPlayer crafter)
+                            {
+                                sendStackInCursor(crafter, remaining);
+                            }
+                        } else
+                        {
+                            markTileDirty();
+                        }
+
+                        if (dropping.getCount() <= 0)
+                            dropping = ItemStack.EMPTY;
+
+                        setCarried(dropping);
+                    }
+                } else if (existingSize > 0)
+                {
+                    int amount = clickedButton == 0 ? existing.getMaxStackSize() : existing.getMaxStackSize() / 2;
+
+                    ItemStack extracted = extractItemsSided(parent, existing, existingSize, amount, false);
+                    if (extracted.getCount() > 0)
+                    {
+                        markTileDirty();
+                    } else
+                    {
+
+                        if (player instanceof ServerPlayer crafter)
+                        {
+                            sendStackInCursor(crafter, extracted);
+                        }
+                    }
+                    setCarried(extracted);
+                }
+
+                broadcastChanges();
+                return;
+            } else if (mode == ClickType.QUICK_MOVE && existingSize > 0)
+            {
+                int amount = existing.getMaxStackSize();
+                if (clickedButton != 0 && amount > 1)
+                    amount /= 2;
+
+                if (amount == 0)
+                    return;
+
+                ItemStack remaining = simulateAddToPlayer(existing, amount);
+
+                if (remaining.getCount() > 0)
+                    amount -= remaining.getCount();
+
+                if (amount > 0)
+                {
+                    ItemStack finalExtract = extractItemsSided(parent, existing, existingSize, amount, false);
+
+                    if (finalExtract.getCount() > 0)
+                    {
+                        addToPlayer(finalExtract);
+
+                        markTileDirty();
+                        broadcastChanges();
+                    }
+                }
+            }
+
+            if (mode != ClickType.CLONE)
+                return;
+        }
+
+        super.clicked(slotId, clickedButton, mode, playerIn);
+    }
+
+    @Nullable
+    private IItemHandler getTileInventory()
+    {
+        return isClient() ? null : tile.getCombinedInventory();
+    }
+
+    private void markTileDirty()
+    {
+        if (!isClient())
+            tile.setChanged();
+    }
+
+    private ItemStack extractItemsSided(@Nullable IItemHandler parent, ItemStack existing, int existingSize, int amount, boolean simulate)
+    {
+        if (isClient() || parent == null)
+        {
+            var copy = existing.copy();
+            copy.setCount(Math.min(existingSize, amount));
+            return copy;
+        }
+        return AutomationHelper.extractItems(parent, existing, amount, simulate);
+    }
+
+    private ItemStack insertItemsSided(@Nullable IItemHandler parent, ItemStack dropping)
+    {
+        if (isClient() || parent == null)
+            return ItemStack.EMPTY;
+        return AutomationHelper.insertItems(parent, dropping);
+    }
+
+    private ItemStack simulateAddToPlayer(ItemStack stack, int amount)
+    {
+        int startIndex = SCROLL_SLOTS;
+        int endIndex = startIndex + PLAYER_SLOTS;
+
+        ItemStack stackCopy = stack.copy();
+        stackCopy.setCount(amount);
+
+        if (!this.simulateInsertStack(stackCopy, startIndex, endIndex))
+        {
+            return stackCopy;
+        }
+
+        if (stackCopy.getCount() <= 0)
+        {
+            return ItemStack.EMPTY;
+        }
+
+        return stackCopy;
+    }
+
+    protected boolean simulateInsertStack(ItemStack stack, int startIndex, int endIndex)
+    {
+        boolean canInsert = false;
+
+        if (stack.isStackable())
+        {
+            for (int i = startIndex; stack.getCount() > 0 && i < endIndex; i++)
+            {
+                Slot slot = this.slots.get(i);
+                ItemStack stackInSlot = slot.getItem();
+
+                if (stackInSlot.getCount() < stackInSlot.getMaxStackSize() && ItemStack.isSame(stackInSlot, stack) && ItemStack.tagMatches(stack, stackInSlot))
+                {
+                    int j = stackInSlot.getCount() + stack.getCount();
+
+                    if (j <= stack.getMaxStackSize())
+                    {
+                        stack.setCount(0);
+                        canInsert = true;
+                    } else
+                    {
+                        stack.shrink(stack.getMaxStackSize() - stackInSlot.getCount());
+                        canInsert = true;
+                    }
+                }
+            }
+        }
+
+        if (stack.getCount() > 0)
+        {
+            for (int i = startIndex; i < endIndex; i++)
+            {
+                Slot slot = this.slots.get(i);
+                ItemStack stackInSlot = slot.getItem();
+
+                if (stackInSlot.getCount() <= 0 && slot.mayPlace(stack))
+                {
+                    stack.setCount(0);
+                    canInsert = true;
+                    break;
+                }
+            }
+        }
+
+        return canInsert;
+    }
+
+    public ItemStack addToPlayer(ItemStack stack)
+    {
+        int startIndex = SCROLL_SLOTS;
+        int endIndex = startIndex + PLAYER_SLOTS;
+
+        ItemStack stackCopy = stack.copy();
+
+        if (!this.moveItemStackTo(stackCopy, startIndex, endIndex, false))
+        {
+            return stackCopy;
+        }
+
+        if (stackCopy.getCount() <= 0)
+        {
+            return ItemStack.EMPTY;
+        }
+
+        return stackCopy;
+    }
+
+    @Override
+    public ItemStack quickMoveStack(Player player, int slotIndex)
+    {
+        Slot slot = this.slots.get(slotIndex);
+
+        if (slot == null || !slot.hasItem())
+        {
+            return ItemStack.EMPTY;
+        }
+
+        if (slotIndex < SCROLL_SLOTS)
+        {
+            // Shouldn't even happen, handled above.
+            return ItemStack.EMPTY;
+        } else
+        {
+            ItemStack stack = slot.getItem();
+            ItemStack stackCopy = stack.copy();
+
+            ItemStack remaining = insertItemsSided(getTileInventory(), stack);
+            if (remaining.getCount() > 0)
+            {
+                if (player instanceof ContainerListener)
+                {
+                    ((ContainerListener) player).slotChanged(this, slotIndex, remaining);
+                }
+
+                if (remaining.getCount() == stackCopy.getCount())
+                {
+                    return ItemStack.EMPTY;
+                }
+
+                markTileDirty();
+                stack.setCount(remaining.getCount());
+                slot.setChanged();
+            } else
+            {
+                markTileDirty();
+                stack.setCount(0);
+                slot.set(ItemStack.EMPTY);
+            }
+
+            slot.onTake(player, stack);
+            return stackCopy;
+        }
+    }
+
+    public int getActualSlotCount()
+    {
+        return scrollInventory.getSlots();
+    }
+
+    public boolean isLowOnPower()
+    {
+        return isLowOnPower.get() != 0;
+    }
+
+    public static class ServerScrollInventory implements IItemHandlerModifiable
+    {
+        final BrowserBlockEntity tile;
+        final List<ItemStack> slots = Lists.newArrayList();
+        private int[] visible = new int[0];
+
+        public ServerScrollInventory(BrowserBlockEntity tile)
+        {
+            this.tile = tile;
+        }
+
+        public void setVisible(int[] visible)
+        {
+            this.visible = visible;
+        }
+
+        public void resetVisible()
+        {
+            visible = new int[0];
+        }
+
+        public void refresh()
+        {
+            IItemHandler inv = tile.getCombinedInventory();
+
+            final List<ItemStack> slotsSeen = Lists.newArrayList();
+
+            slots.clear();
+
+            if (inv == null)
+                return;
+
+            int invSlots = inv.getSlots();
+            for (int j = 0; j < invSlots; j++)
+            {
+                ItemStack invStack = inv.getStackInSlot(j);
+                if (invStack.getCount() <= 0)
+                    continue;
+
+                boolean found = false;
+
+                for (ItemStack cachedStack : slotsSeen)
+                {
+                    if (ItemStack.isSame(cachedStack, invStack) && ItemStack.tagMatches(cachedStack, invStack))
+                    {
+                        cachedStack.grow(invStack.getCount());
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (!found)
+                {
+                    ItemStack stack = invStack.copy();
+                    slotsSeen.add(stack);
+
+                    slots.add(stack);
+                }
+            }
+        }
+
+        public int getRealSizeInventory()
+        {
+            return slots.size();
+        }
+
+        @Override
+        public int getSlots()
+        {
+            return visible.length;
+        }
+
+        @Override
+        public ItemStack getStackInSlot(int index)
+        {
+            if (index >= visible.length)
+                return ItemStack.EMPTY;
+            int i = visible[index];
+            if (i >= slots.size())
+                return ItemStack.EMPTY;
+            return slots.get(visible[index]);
+        }
+
+        public ItemStack getStack(int index)
+        {
+            return slots.get(index);
+        }
+
+        @Override
+        public ItemStack insertItem(int slot, ItemStack stack, boolean simulate)
+        {
+            return ItemStack.EMPTY;
+        }
+
+        @Override
+        public ItemStack extractItem(int slot, int amount, boolean simulate)
+        {
+            return ItemStack.EMPTY;
+        }
+
+        @Override
+        public int getSlotLimit(int slot)
+        {
+            return 64;
+        }
+
+        @Override
+        public boolean isItemValid(int slot, @Nonnull ItemStack stack)
+        {
+            return true;
+        }
+
+        @Override
+        public void setStackInSlot(int slot, ItemStack stack)
+        {
+        }
+    }
+
+    public class ClientScrollInventory implements IItemHandlerModifiable
+    {
+        private int[] indices;
+        private NonNullList<ItemStack> stacks;
+
+        public ClientScrollInventory()
+        {
+        }
+
+        public void setArray(final NonNullList<ItemStack> stacks)
+        {
+            this.stacks = stacks;
+
+            final List<Integer> indices = Lists.newArrayList();
+
+            final List<Component> itemData = Lists.newArrayList();
+
+            int indexx = 0;
+            for (ItemStack invStack : stacks)
+            {
+                ItemStack stack = invStack.copy();
+
+                boolean matchesSearch = true;
+                if (!Strings.isNullOrEmpty(filterText))
+                {
+                    itemData.clear();
+                    Item item = invStack.getItem();
+                    itemData.add(stack.getHoverName());
+                    itemData.add(Component.literal(ForgeRegistries.ITEMS.getKey(item).toString()));
+                    item.appendHoverText(stack, player.level, itemData, TooltipFlag.Default.NORMAL);
+                    matchesSearch = false;
+                    for (Component s : itemData)
+                    {
+                        if (StringUtils.containsIgnoreCase(s.getString(), filterText))
+                        {
+                            matchesSearch = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (matchesSearch)
+                {
+                    indices.add(indexx);
+                }
+                indexx++;
+            }
+
+            if (sortMode != null)
+            {
+                switch (sortMode)
+                {
+                case ALPHABETIC:
+                    indices.sort((ia, ib) -> {
+                        ItemStack a = stacks.get(ia);
+                        ItemStack b = stacks.get(ib);
+                        return a.getHoverName().getString().compareToIgnoreCase(b.getHoverName().getString());
+                    });
+                    break;
+                case STACK_SIZE:
+                    indices.sort((ia, ib) -> {
+                        ItemStack a = stacks.get(ia);
+                        ItemStack b = stacks.get(ib);
+                        int diff = a.getCount() - b.getCount();
+                        if (diff > 0)
+                            return -1;
+                        if (diff < 0)
+                            return 1;
+                        return a.getHoverName().getString().compareToIgnoreCase(b.getHoverName().getString());
+                    });
+                    break;
+                }
+            }
+
+            this.indices = new int[indices.size()];
+            for (int i = 0; i < this.indices.length; i++)
+            {
+                this.indices[i] = indices.get(i);
+            }
+        }
+
+        @Override
+        public int getSlots()
+        {
+            return indices.length;
+        }
+
+        @Override
+        public ItemStack getStackInSlot(int slot)
+        {
+            if ((slot + scroll) >= indices.length)
+                return ItemStack.EMPTY;
+            ItemStack stack = stacks.get(indices[slot + scroll]);
+            stack = stack.copy();
+            stack.setCount(1);
+            return stack;
+        }
+
+        @Override
+        public ItemStack insertItem(int slot, ItemStack stack, boolean simulate)
+        {
+            return ItemStack.EMPTY;
+        }
+
+        @Override
+        public ItemStack extractItem(int slot, int amount, boolean simulate)
+        {
+            return ItemStack.EMPTY;
+        }
+
+        @Override
+        public int getSlotLimit(int slot)
+        {
+            return 64;
+        }
+
+        @Override
+        public boolean isItemValid(int slot, @Nonnull ItemStack stack)
+        {
+            return true;
+        }
+
+        @Override
+        public void setStackInSlot(int slot, ItemStack stack)
+        {
+            if ((slot + scroll) < indices.length)
+                stacks.set(indices[slot + scroll], stack);
+        }
+
+        public int getStackSizeForSlot(int slot)
+        {
+            if ((slot + scroll) >= indices.length)
+                return 0;
+            return stacks.get(indices[slot + scroll]).getCount();
+        }
+
+        public int[] getIndices()
+        {
+            int from = Math.max(0, Math.min(scroll, indices.length - 1));
+            int to = Math.min(from + SCROLL_SLOTS, indices.length);
+            return Arrays.copyOfRange(indices, from, to);
+        }
+    }
 }

--- a/src/main/java/dev/gigaherz/enderrift/automation/browser/AbstractBrowserContainer.java
+++ b/src/main/java/dev/gigaherz/enderrift/automation/browser/AbstractBrowserContainer.java
@@ -104,7 +104,8 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
         {
             this.tile = null;
             scrollInventory = new ClientScrollInventory();
-        } else
+        }
+        else
         {
             this.tile = Objects.requireNonNull(tileEntity);
             scrollInventory = new ServerScrollInventory(tile);
@@ -277,7 +278,8 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
         if (isClient())
         {
             EnderRiftMod.CHANNEL.sendToServer(new SetVisibleSlots(containerId, visible));
-        } else
+        }
+        else
         {
             getServer().setVisible(visible);
         }
@@ -347,12 +349,14 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
                             {
                                 sendStackInCursor(crafter, remaining);
                             }
-                        } else
+                        }
+                        else
                         {
                             markTileDirty();
                         }
                         setCarried(remaining);
-                    } else
+                    }
+                    else
                     {
                         int amount = 1;
 
@@ -372,7 +376,8 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
                             {
                                 sendStackInCursor(crafter, remaining);
                             }
-                        } else
+                        }
+                        else
                         {
                             markTileDirty();
                         }
@@ -382,7 +387,8 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
 
                         setCarried(dropping);
                     }
-                } else if (existingSize > 0)
+                }
+                else if (existingSize > 0)
                 {
                     int amount = clickedButton == 0 ? existing.getMaxStackSize() : existing.getMaxStackSize() / 2;
 
@@ -390,7 +396,8 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
                     if (extracted.getCount() > 0)
                     {
                         markTileDirty();
-                    } else
+                    }
+                    else
                     {
 
                         if (player instanceof ServerPlayer crafter)
@@ -403,7 +410,8 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
 
                 broadcastChanges();
                 return;
-            } else if (mode == ClickType.QUICK_MOVE && existingSize > 0)
+            }
+            else if (mode == ClickType.QUICK_MOVE && existingSize > 0)
             {
                 int amount = existing.getMaxStackSize();
                 if (clickedButton != 0 && amount > 1)
@@ -508,7 +516,8 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
                     {
                         stack.setCount(0);
                         canInsert = true;
-                    } else
+                    }
+                    else
                     {
                         stack.shrink(stack.getMaxStackSize() - stackInSlot.getCount());
                         canInsert = true;
@@ -570,7 +579,8 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
         {
             // Shouldn't even happen, handled above.
             return ItemStack.EMPTY;
-        } else
+        }
+        else
         {
             ItemStack stack = slot.getItem();
             ItemStack stackCopy = stack.copy();
@@ -591,7 +601,8 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
                 markTileDirty();
                 stack.setCount(remaining.getCount());
                 slot.setChanged();
-            } else
+            }
+            else
             {
                 markTileDirty();
                 stack.setCount(0);

--- a/src/main/java/dev/gigaherz/enderrift/automation/browser/AbstractBrowserContainer.java
+++ b/src/main/java/dev/gigaherz/enderrift/automation/browser/AbstractBrowserContainer.java
@@ -395,7 +395,7 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
                 {
                     int amount = clickedButton == 0 
                             ? existing.getMaxStackSize() 
-                            : existing.getMaxStackSize() / 2;
+                            : Math.min(existing.getCount() / 2, existing.getMaxStackSize() / 2);
 
                     ItemStack extracted = extractItemsSided(parent, existing, existingSize, amount, false);
                     if (extracted.getCount() > 0)

--- a/src/main/java/dev/gigaherz/enderrift/automation/browser/AbstractBrowserContainer.java
+++ b/src/main/java/dev/gigaherz/enderrift/automation/browser/AbstractBrowserContainer.java
@@ -115,7 +115,8 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
         {
             for (int x = 0; x < SCROLL_COLUMNS; x++)
             {
-                addSlot(new SlotFake(scrollInventory, x + y * SCROLL_COLUMNS, LEFT + x * SLOT_WIDTH, TOP + y * SLOT_HEIGHT));
+                addSlot(new SlotFake(scrollInventory, x + y * SCROLL_COLUMNS, 
+                        LEFT + x * SLOT_WIDTH, TOP + y * SLOT_HEIGHT));
             }
         }
 
@@ -135,7 +136,9 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
         {
             for (int x = 0; x < 9; x++)
             {
-                addSlot(new Slot(playerInventory, x + y * 9 + 9, LEFT + x * SLOT_WIDTH, top + y * SLOT_HEIGHT));
+                addSlot(new Slot(playerInventory, 
+                        x + y * 9 + 9, 
+                        LEFT + x * SLOT_WIDTH, top + y * SLOT_HEIGHT));
             }
         }
 
@@ -155,6 +158,7 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
     @Override
     public void broadcastChanges()
     {
+        
         if (isClient())
             return;
 
@@ -170,6 +174,7 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
         List<Integer> indicesChanged = Lists.newArrayList();
         List<ItemStack> stacksChanged = Lists.newArrayList();
 
+        
         newLength = serverInv.getRealSizeInventory();
         if (newLength != oldLength)
         {
@@ -234,9 +239,7 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
         NonNullList<ItemStack> oldStacks = currentStacks;
         currentStacks = NonNullList.withSize(newLength, ItemStack.EMPTY);
         for (int i = 0; i < Math.min(newLength, oldLength); i++)
-        {
-            currentStacks.set(i, oldStacks.get(i));
-        }
+        { currentStacks.set(i, oldStacks.get(i)); }
     }
 
     private void sendStackInCursor(ServerPlayer player, ItemStack newStack)
@@ -390,7 +393,9 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
                 }
                 else if (existingSize > 0)
                 {
-                    int amount = clickedButton == 0 ? existing.getMaxStackSize() : existing.getMaxStackSize() / 2;
+                    int amount = clickedButton == 0 
+                            ? existing.getMaxStackSize() 
+                            : existing.getMaxStackSize() / 2;
 
                     ItemStack extracted = extractItemsSided(parent, existing, existingSize, amount, false);
                     if (extracted.getCount() > 0)
@@ -508,7 +513,9 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
                 Slot slot = this.slots.get(i);
                 ItemStack stackInSlot = slot.getItem();
 
-                if (stackInSlot.getCount() < stackInSlot.getMaxStackSize() && ItemStack.isSame(stackInSlot, stack) && ItemStack.tagMatches(stack, stackInSlot))
+                if (stackInSlot.getCount() < stackInSlot.getMaxStackSize() 
+                        && ItemStack.isSame(stackInSlot, stack)
+                        && ItemStack.tagMatches(stack, stackInSlot))
                 {
                     int j = stackInSlot.getCount() + stack.getCount();
 
@@ -795,24 +802,24 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
                 switch (sortMode)
                 {
                 case ALPHABETIC:
-                    indices.sort((ia, ib) -> {
-                        ItemStack a = stacks.get(ia);
-                        ItemStack b = stacks.get(ib);
-                        return a.getHoverName().getString().compareToIgnoreCase(b.getHoverName().getString());
-                    });
-                    break;
+                        indices.sort((ia, ib) -> 
+                        {
+                            ItemStack a = stacks.get(ia);
+                            ItemStack b = stacks.get(ib);
+                            return a.getHoverName().getString().compareToIgnoreCase(b.getHoverName().getString());
+                        });
+                        break;
                 case STACK_SIZE:
-                    indices.sort((ia, ib) -> {
-                        ItemStack a = stacks.get(ia);
-                        ItemStack b = stacks.get(ib);
-                        int diff = a.getCount() - b.getCount();
-                        if (diff > 0)
-                            return -1;
-                        if (diff < 0)
-                            return 1;
-                        return a.getHoverName().getString().compareToIgnoreCase(b.getHoverName().getString());
-                    });
-                    break;
+                        indices.sort((ia, ib) -> 
+                        {
+                            ItemStack a = stacks.get(ia);
+                            ItemStack b = stacks.get(ib);
+                            int diff = a.getCount() - b.getCount();
+                            if (diff > 0) return -1;
+                            if (diff < 0) return 1;
+                            return a.getHoverName().getString().compareToIgnoreCase(b.getHoverName().getString());
+                        });
+                        break;
                 }
             }
 

--- a/src/main/java/dev/gigaherz/enderrift/automation/browser/AbstractBrowserContainer.java
+++ b/src/main/java/dev/gigaherz/enderrift/automation/browser/AbstractBrowserContainer.java
@@ -29,8 +29,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
-public class AbstractBrowserContainer extends AbstractContainerMenu
-{
+public class AbstractBrowserContainer extends AbstractContainerMenu {
     protected final static int LEFT = 8;
     protected final static int TOP = 18;
     protected final static int SLOT_WIDTH = 18;
@@ -57,66 +56,54 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
     public SortMode sortMode = SortMode.STACK_SIZE;
     public String filterText = "";
 
-    private DataSlot isLowOnPower = new DataSlot()
-    {
+    private DataSlot isLowOnPower = new DataSlot() {
         boolean value = false;
 
         @Override
-        public int get()
-        {
+        public int get() {
             return (isClient() ? value : tile.isLowOnPower()) ? 1 : 0;
         }
 
         @Override
-        public void set(int value)
-        {
+        public void set(int value) {
             this.value = value != 0;
         }
     };
 
-    public final boolean isClient()
-    {
+    public final boolean isClient() {
         return tile == null;
     }
 
-    public ClientScrollInventory getClient()
-    {
+    public ClientScrollInventory getClient() {
         if (!isClient())
             throw new IllegalStateException("Attempted to get client inventory on the server");
         return (ClientScrollInventory) scrollInventory;
     }
 
-    public ServerScrollInventory getServer()
-    {
+    public ServerScrollInventory getServer() {
         if (isClient())
             throw new IllegalStateException("Attempted to get server inventory on the client");
         return (ServerScrollInventory) scrollInventory;
     }
 
-    protected AbstractBrowserContainer(MenuType<? extends AbstractBrowserContainer> type, int id, @Nullable BrowserBlockEntity tileEntity, Inventory playerInventory)
-    {
+    protected AbstractBrowserContainer(MenuType<? extends AbstractBrowserContainer> type, int id, @Nullable BrowserBlockEntity tileEntity,
+        Inventory playerInventory) {
         super(type, id);
 
         this.player = playerInventory.player;
         boolean isClient = player.level.isClientSide;
 
-        if (isClient)
-        {
+        if (isClient) {
             this.tile = null;
             scrollInventory = new ClientScrollInventory();
-        }
-        else
-        {
+        } else {
             this.tile = Objects.requireNonNull(tileEntity);
             scrollInventory = new ServerScrollInventory(tile);
         }
 
-        for (int y = 0; y < SCROLL_ROWS; y++)
-        {
-            for (int x = 0; x < SCROLL_COLUMNS; x++)
-            {
-                addSlot(new SlotFake(scrollInventory, x + y * SCROLL_COLUMNS,
-                        LEFT + x * SLOT_WIDTH, TOP + y * SLOT_HEIGHT));
+        for (int y = 0; y < SCROLL_ROWS; y++) {
+            for (int x = 0; x < SCROLL_COLUMNS; x++) {
+                addSlot(new SlotFake(scrollInventory, x + y * SCROLL_COLUMNS, LEFT + x * SLOT_WIDTH, TOP + y * SLOT_HEIGHT));
             }
         }
 
@@ -125,46 +112,35 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
         addDataSlot(isLowOnPower);
     }
 
-    protected void bindPlayerInventory(Inventory playerInventory)
-    {
+    protected void bindPlayerInventory(Inventory playerInventory) {
         bindPlayerInventory(playerInventory, TOP + SCROLL_ROWS * SLOT_HEIGHT + 14);
     }
 
-    protected void bindPlayerInventory(Inventory playerInventory, int top)
-    {
-        for (int y = 0; y < 3; y++)
-        {
-            for (int x = 0; x < 9; x++)
-            {
-                addSlot(new Slot(playerInventory,
-                        x + y * 9 + 9,
-                        LEFT + x * SLOT_WIDTH, top + y * SLOT_HEIGHT));
+    protected void bindPlayerInventory(Inventory playerInventory, int top) {
+        for (int y = 0; y < 3; y++) {
+            for (int x = 0; x < 9; x++) {
+                addSlot(new Slot(playerInventory, x + y * 9 + 9, LEFT + x * SLOT_WIDTH, top + y * SLOT_HEIGHT));
             }
         }
 
         top += 3 * SLOT_HEIGHT + 4;
-        for (int x = 0; x < 9; x++)
-        {
+        for (int x = 0; x < 9; x++) {
             addSlot(new Slot(playerInventory, x, LEFT + x * SLOT_WIDTH, top));
         }
     }
 
     @Override
-    public boolean stillValid(Player player)
-    {
+    public boolean stillValid(Player player) {
         return true;
     }
 
-
     @Override
-    public void broadcastChanges()
-    {
+    public void broadcastChanges() {
         if (isClient())
             return;
 
         ServerScrollInventory serverInv = getServer();
-        if (prevChangeCount != tile.getChangeCount())
-        {
+        if (prevChangeCount != tile.getChangeCount()) {
             serverInv.refresh();
             prevChangeCount = tile.getChangeCount();
         }
@@ -174,20 +150,16 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
         List<Integer> indicesChanged = Lists.newArrayList();
         List<ItemStack> stacksChanged = Lists.newArrayList();
 
-
         newLength = serverInv.getRealSizeInventory();
-        if (newLength != oldLength)
-        {
+        if (newLength != oldLength) {
             changeSize(oldLength, newLength);
         }
 
-        for (int i = 0; i < newLength; ++i)
-        {
+        for (int i = 0; i < newLength; ++i) {
             ItemStack newStack = serverInv.getStack(i);
             ItemStack current = currentStacks.get(i);
 
-            if (!ItemStack.matches(current, newStack))
-            {
+            if (!ItemStack.matches(current, newStack)) {
                 current = newStack.copy();
                 currentStacks.set(i, current);
 
@@ -196,68 +168,58 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
             }
         }
 
-        for (int i = SCROLL_SLOTS; i < this.slots.size(); ++i)
-        {
+        for (int i = SCROLL_SLOTS; i < this.slots.size(); ++i) {
             ItemStack inSlot = slots.get(i).getItem();
             ItemStack inCache = lastSlots.get(i);
 
-            if (!ItemStack.matches(inCache, inSlot))
-            {
+            if (!ItemStack.matches(inCache, inSlot)) {
                 inCache = inSlot.copy();
                 this.lastSlots.set(i, inCache);
 
-                for (ContainerListener crafter : this.containerListeners)
-                {
+                for (ContainerListener crafter : this.containerListeners) {
                     crafter.slotChanged(this, i, inCache);
                 }
             }
         }
 
-        if (player instanceof ServerPlayer crafter)
-        {
-            if (newLength != oldLength || indicesChanged.size() > 0)
-            {
-                EnderRiftMod.CHANNEL.sendTo(new SendSlotChanges(containerId, newLength, indicesChanged, stacksChanged), crafter.connection.getConnection(), NetworkDirection.PLAY_TO_CLIENT);
+        if (player instanceof ServerPlayer crafter) {
+            if (newLength != oldLength || indicesChanged.size() > 0) {
+                EnderRiftMod.CHANNEL.sendTo(new SendSlotChanges(containerId, newLength, indicesChanged, stacksChanged),
+                    crafter.connection.getConnection(), NetworkDirection.PLAY_TO_CLIENT);
             }
 
             ItemStack newStack = getCarried();
 
-            if (!ItemStack.matches(stackInCursor, newStack))
-            {
+            if (!ItemStack.matches(stackInCursor, newStack)) {
                 sendStackInCursor(crafter, newStack);
             }
         }
 
-        if (newLength != oldLength || indicesChanged.size() > 0)
-        {
+        if (newLength != oldLength || indicesChanged.size() > 0) {
             serverInv.resetVisible();
         }
     }
 
-    private void changeSize(int oldLength, int newLength)
-    {
+    private void changeSize(int oldLength, int newLength) {
         NonNullList<ItemStack> oldStacks = currentStacks;
         currentStacks = NonNullList.withSize(newLength, ItemStack.EMPTY);
-        for (int i = 0; i < Math.min(newLength, oldLength); i++)
-        { currentStacks.set(i, oldStacks.get(i)); }
+        for (int i = 0; i < Math.min(newLength, oldLength); i++) {
+            currentStacks.set(i, oldStacks.get(i));
+        }
     }
 
-    private void sendStackInCursor(ServerPlayer player, ItemStack newStack)
-    {
+    private void sendStackInCursor(ServerPlayer player, ItemStack newStack) {
         stackInCursor = newStack.copy();
 
         player.connection.send(new ClientboundContainerSetSlotPacket(-1, incrementStateId(), -1, newStack));
     }
 
-    public void slotsChanged(int slotCount, List<Integer> indices, List<ItemStack> stacks)
-    {
-        if (slotCount != currentStacks.size())
-        {
+    public void slotsChanged(int slotCount, List<Integer> indices, List<ItemStack> stacks) {
+        if (slotCount != currentStacks.size()) {
             changeSize(currentStacks.size(), slotCount);
         }
 
-        for (int i = 0; i < indices.size(); i++)
-        {
+        for (int i = 0; i < indices.size(); i++) {
             int slot = indices.get(i);
             ItemStack stack = stacks.get(i);
 
@@ -271,32 +233,25 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
     }
 
     @Override
-    public void initializeContents(int p_182411_, List<ItemStack> p_182412_, ItemStack p_182413_)
-    {
+    public void initializeContents(int p_182411_, List<ItemStack> p_182412_, ItemStack p_182413_) {
         super.initializeContents(p_182411_, List.of(), p_182413_);
     }
 
-    public void setVisibleSlots(int[] visible)
-    {
-        if (isClient())
-        {
+    public void setVisibleSlots(int[] visible) {
+        if (isClient()) {
             EnderRiftMod.CHANNEL.sendToServer(new SetVisibleSlots(containerId, visible));
-        }
-        else
-        {
+        } else {
             getServer().setVisible(visible);
         }
     }
 
-    public void setScrollPos(int scroll)
-    {
+    public void setScrollPos(int scroll) {
         this.scroll = scroll;
 
         setVisibleSlots(getClient().getIndices());
     }
 
-    public void setSortMode(SortMode sortMode)
-    {
+    public void setSortMode(SortMode sortMode) {
         this.sortMode = sortMode;
         this.scroll = 0;
 
@@ -306,8 +261,7 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
         setVisibleSlots(clientInv.getIndices());
     }
 
-    public void setFilterText(String text)
-    {
+    public void setFilterText(String text) {
         this.filterText = text.toLowerCase();
         this.scroll = 0;
 
@@ -318,49 +272,37 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
     }
 
     @Override
-    public void setItem(int slotID, int stateId, ItemStack stack)
-    {
+    public void setItem(int slotID, int stateId, ItemStack stack) {
         super.setItem(slotID, stateId, stack);
     }
 
     @Override
-    public void clicked(int slotId, int clickedButton, ClickType mode, Player playerIn)
-    {
-        if (slotId >= 0 && slotId < SCROLL_SLOTS)
-        {
+    public void clicked(int slotId, int clickedButton, ClickType mode, Player playerIn) {
+        if (slotId >= 0 && slotId < SCROLL_SLOTS) {
             IItemHandler parent = getTileInventory();
 
             Slot slot = this.slots.get(slotId);
             ItemStack existing = slot.getItem();
             int existingSize = isClient() ? getClient().getStackSizeForSlot(slotId) : existing.getCount();
 
-            if (mode == ClickType.PICKUP)
-            {
+            if (mode == ClickType.PICKUP) {
                 ItemStack dropping = getCarried();
 
-                if (dropping.getCount() > 0)
-                {
-                    if (clickedButton == 0)
-                    {
+                if (dropping.getCount() > 0) {
+                    if (clickedButton == 0) {
                         ItemStack remaining = insertItemsSided(parent, dropping);
-                        if (remaining.getCount() > 0)
-                        {
+                        if (remaining.getCount() > 0) {
                             if (dropping.getCount() != remaining.getCount())
                                 markTileDirty();
 
-                            if (player instanceof ServerPlayer crafter)
-                            {
+                            if (player instanceof ServerPlayer crafter) {
                                 sendStackInCursor(crafter, remaining);
                             }
-                        }
-                        else
-                        {
+                        } else {
                             markTileDirty();
                         }
                         setCarried(remaining);
-                    }
-                    else
-                    {
+                    } else {
                         int amount = 1;
 
                         ItemStack push = dropping.copy();
@@ -369,19 +311,15 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
 
                         dropping.shrink(push.getCount());
 
-                        if (remaining.getCount() > 0)
-                        {
+                        if (remaining.getCount() > 0) {
                             if (push.getCount() != remaining.getCount())
                                 markTileDirty();
                             dropping.grow(remaining.getCount());
 
-                            if (player instanceof ServerPlayer crafter)
-                            {
+                            if (player instanceof ServerPlayer crafter) {
                                 sendStackInCursor(crafter, remaining);
                             }
-                        }
-                        else
-                        {
+                        } else {
                             markTileDirty();
                         }
 
@@ -390,23 +328,15 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
 
                         setCarried(dropping);
                     }
-                }
-                else if (existingSize > 0)
-                {
-                    int amount = clickedButton == 0
-                            ? existing.getMaxStackSize()
-                            : existing.getMaxStackSize() / 2;
+                } else if (existingSize > 0) {
+                    int amount = clickedButton == 0 ? existing.getMaxStackSize() : existing.getMaxStackSize() / 2;
 
                     ItemStack extracted = extractItemsSided(parent, existing, existingSize, amount, false);
-                    if (extracted.getCount() > 0)
-                    {
+                    if (extracted.getCount() > 0) {
                         markTileDirty();
-                    }
-                    else
-                    {
+                    } else {
 
-                        if (player instanceof ServerPlayer crafter)
-                        {
+                        if (player instanceof ServerPlayer crafter) {
                             sendStackInCursor(crafter, extracted);
                         }
                     }
@@ -415,9 +345,7 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
 
                 broadcastChanges();
                 return;
-            }
-            else if (mode == ClickType.QUICK_MOVE && existingSize > 0)
-            {
+            } else if (mode == ClickType.QUICK_MOVE && existingSize > 0) {
                 int amount = existing.getMaxStackSize();
                 if (clickedButton != 0 && amount > 1)
                     amount /= 2;
@@ -430,12 +358,10 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
                 if (remaining.getCount() > 0)
                     amount -= remaining.getCount();
 
-                if (amount > 0)
-                {
+                if (amount > 0) {
                     ItemStack finalExtract = extractItemsSided(parent, existing, existingSize, amount, false);
 
-                    if (finalExtract.getCount() > 0)
-                    {
+                    if (finalExtract.getCount() > 0) {
                         addToPlayer(finalExtract);
 
                         markTileDirty();
@@ -452,21 +378,17 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
     }
 
     @Nullable
-    private IItemHandler getTileInventory()
-    {
+    private IItemHandler getTileInventory() {
         return isClient() ? null : tile.getCombinedInventory();
     }
 
-    private void markTileDirty()
-    {
+    private void markTileDirty() {
         if (!isClient())
             tile.setChanged();
     }
 
-    private ItemStack extractItemsSided(@Nullable IItemHandler parent, ItemStack existing, int existingSize, int amount, boolean simulate)
-    {
-        if (isClient() || parent == null)
-        {
+    private ItemStack extractItemsSided(@Nullable IItemHandler parent, ItemStack existing, int existingSize, int amount, boolean simulate) {
+        if (isClient() || parent == null) {
             var copy = existing.copy();
             copy.setCount(Math.min(existingSize, amount));
             return copy;
@@ -474,58 +396,46 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
         return AutomationHelper.extractItems(parent, existing, amount, simulate);
     }
 
-    private ItemStack insertItemsSided(@Nullable IItemHandler parent, ItemStack dropping)
-    {
+    private ItemStack insertItemsSided(@Nullable IItemHandler parent, ItemStack dropping) {
         if (isClient() || parent == null)
             return ItemStack.EMPTY;
         return AutomationHelper.insertItems(parent, dropping);
     }
 
-    private ItemStack simulateAddToPlayer(ItemStack stack, int amount)
-    {
+    private ItemStack simulateAddToPlayer(ItemStack stack, int amount) {
         int startIndex = SCROLL_SLOTS;
         int endIndex = startIndex + PLAYER_SLOTS;
 
         ItemStack stackCopy = stack.copy();
         stackCopy.setCount(amount);
 
-        if (!this.simulateInsertStack(stackCopy, startIndex, endIndex))
-        {
+        if (!this.simulateInsertStack(stackCopy, startIndex, endIndex)) {
             return stackCopy;
         }
 
-        if (stackCopy.getCount() <= 0)
-        {
+        if (stackCopy.getCount() <= 0) {
             return ItemStack.EMPTY;
         }
 
         return stackCopy;
     }
 
-    protected boolean simulateInsertStack(ItemStack stack, int startIndex, int endIndex)
-    {
+    protected boolean simulateInsertStack(ItemStack stack, int startIndex, int endIndex) {
         boolean canInsert = false;
 
-        if (stack.isStackable())
-        {
-            for (int i = startIndex; stack.getCount() > 0 && i < endIndex; i++)
-            {
+        if (stack.isStackable()) {
+            for (int i = startIndex; stack.getCount() > 0 && i < endIndex; i++) {
                 Slot slot = this.slots.get(i);
                 ItemStack stackInSlot = slot.getItem();
 
-                if (stackInSlot.getCount() < stackInSlot.getMaxStackSize()
-                        && ItemStack.isSame(stackInSlot, stack)
-                        && ItemStack.tagMatches(stack, stackInSlot))
-                {
+                if (stackInSlot.getCount() < stackInSlot.getMaxStackSize() && ItemStack.isSame(stackInSlot, stack)
+                    && ItemStack.tagMatches(stack, stackInSlot)) {
                     int j = stackInSlot.getCount() + stack.getCount();
 
-                    if (j <= stack.getMaxStackSize())
-                    {
+                    if (j <= stack.getMaxStackSize()) {
                         stack.setCount(0);
                         canInsert = true;
-                    }
-                    else
-                    {
+                    } else {
                         stack.shrink(stack.getMaxStackSize() - stackInSlot.getCount());
                         canInsert = true;
                     }
@@ -533,15 +443,12 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
             }
         }
 
-        if (stack.getCount() > 0)
-        {
-            for (int i = startIndex; i < endIndex; i++)
-            {
+        if (stack.getCount() > 0) {
+            for (int i = startIndex; i < endIndex; i++) {
                 Slot slot = this.slots.get(i);
                 ItemStack stackInSlot = slot.getItem();
 
-                if (stackInSlot.getCount() <= 0 && slot.mayPlace(stack))
-                {
+                if (stackInSlot.getCount() <= 0 && slot.mayPlace(stack)) {
                     stack.setCount(0);
                     canInsert = true;
                     break;
@@ -552,20 +459,17 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
         return canInsert;
     }
 
-    public ItemStack addToPlayer(ItemStack stack)
-    {
+    public ItemStack addToPlayer(ItemStack stack) {
         int startIndex = SCROLL_SLOTS;
         int endIndex = startIndex + PLAYER_SLOTS;
 
         ItemStack stackCopy = stack.copy();
 
-        if (!this.moveItemStackTo(stackCopy, startIndex, endIndex, false))
-        {
+        if (!this.moveItemStackTo(stackCopy, startIndex, endIndex, false)) {
             return stackCopy;
         }
 
-        if (stackCopy.getCount() <= 0)
-        {
+        if (stackCopy.getCount() <= 0) {
             return ItemStack.EMPTY;
         }
 
@@ -573,44 +477,34 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
     }
 
     @Override
-    public ItemStack quickMoveStack(Player player, int slotIndex)
-    {
+    public ItemStack quickMoveStack(Player player, int slotIndex) {
         Slot slot = this.slots.get(slotIndex);
 
-        if (slot == null || !slot.hasItem())
-        {
+        if (slot == null || !slot.hasItem()) {
             return ItemStack.EMPTY;
         }
 
-        if (slotIndex < SCROLL_SLOTS)
-        {
+        if (slotIndex < SCROLL_SLOTS) {
             // Shouldn't even happen, handled above.
             return ItemStack.EMPTY;
-        }
-        else
-        {
+        } else {
             ItemStack stack = slot.getItem();
             ItemStack stackCopy = stack.copy();
 
             ItemStack remaining = insertItemsSided(getTileInventory(), stack);
-            if (remaining.getCount() > 0)
-            {
-                if (player instanceof ContainerListener)
-                {
+            if (remaining.getCount() > 0) {
+                if (player instanceof ContainerListener) {
                     ((ContainerListener) player).slotChanged(this, slotIndex, remaining);
                 }
 
-                if (remaining.getCount() == stackCopy.getCount())
-                {
+                if (remaining.getCount() == stackCopy.getCount()) {
                     return ItemStack.EMPTY;
                 }
 
                 markTileDirty();
                 stack.setCount(remaining.getCount());
                 slot.setChanged();
-            }
-            else
-            {
+            } else {
                 markTileDirty();
                 stack.setCount(0);
                 slot.set(ItemStack.EMPTY);
@@ -621,39 +515,32 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
         }
     }
 
-    public int getActualSlotCount()
-    {
+    public int getActualSlotCount() {
         return scrollInventory.getSlots();
     }
 
-    public boolean isLowOnPower()
-    {
+    public boolean isLowOnPower() {
         return isLowOnPower.get() != 0;
     }
 
-    public static class ServerScrollInventory implements IItemHandlerModifiable
-    {
+    public static class ServerScrollInventory implements IItemHandlerModifiable {
         final BrowserBlockEntity tile;
         final List<ItemStack> slots = Lists.newArrayList();
         private int[] visible = new int[0];
 
-        public ServerScrollInventory(BrowserBlockEntity tile)
-        {
+        public ServerScrollInventory(BrowserBlockEntity tile) {
             this.tile = tile;
         }
 
-        public void setVisible(int[] visible)
-        {
+        public void setVisible(int[] visible) {
             this.visible = visible;
         }
 
-        public void resetVisible()
-        {
+        public void resetVisible() {
             visible = new int[0];
         }
 
-        public void refresh()
-        {
+        public void refresh() {
             IItemHandler inv = tile.getCombinedInventory();
 
             final List<ItemStack> slotsSeen = Lists.newArrayList();
@@ -664,26 +551,22 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
                 return;
 
             int invSlots = inv.getSlots();
-            for (int j = 0; j < invSlots; j++)
-            {
+            for (int j = 0; j < invSlots; j++) {
                 ItemStack invStack = inv.getStackInSlot(j);
                 if (invStack.getCount() <= 0)
                     continue;
 
                 boolean found = false;
 
-                for (ItemStack cachedStack : slotsSeen)
-                {
-                    if (ItemStack.isSame(cachedStack, invStack) && ItemStack.tagMatches(cachedStack, invStack))
-                    {
+                for (ItemStack cachedStack : slotsSeen) {
+                    if (ItemStack.isSame(cachedStack, invStack) && ItemStack.tagMatches(cachedStack, invStack)) {
                         cachedStack.grow(invStack.getCount());
                         found = true;
                         break;
                     }
                 }
 
-                if (!found)
-                {
+                if (!found) {
                     ItemStack stack = invStack.copy();
                     slotsSeen.add(stack);
 
@@ -692,20 +575,17 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
             }
         }
 
-        public int getRealSizeInventory()
-        {
+        public int getRealSizeInventory() {
             return slots.size();
         }
 
         @Override
-        public int getSlots()
-        {
+        public int getSlots() {
             return visible.length;
         }
 
         @Override
-        public ItemStack getStackInSlot(int index)
-        {
+        public ItemStack getStackInSlot(int index) {
             if (index >= visible.length)
                 return ItemStack.EMPTY;
             int i = visible[index];
@@ -714,52 +594,41 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
             return slots.get(visible[index]);
         }
 
-        public ItemStack getStack(int index)
-        {
+        public ItemStack getStack(int index) {
             return slots.get(index);
         }
 
         @Override
-        public ItemStack insertItem(int slot, ItemStack stack, boolean simulate)
-        {
+        public ItemStack insertItem(int slot, ItemStack stack, boolean simulate) {
             return ItemStack.EMPTY;
         }
 
         @Override
-        public ItemStack extractItem(int slot, int amount, boolean simulate)
-        {
+        public ItemStack extractItem(int slot, int amount, boolean simulate) {
             return ItemStack.EMPTY;
         }
 
         @Override
-        public int getSlotLimit(int slot)
-        {
+        public int getSlotLimit(int slot) {
             return 64;
         }
 
         @Override
-        public boolean isItemValid(int slot, @Nonnull ItemStack stack)
-        {
+        public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
             return true;
         }
 
         @Override
-        public void setStackInSlot(int slot, ItemStack stack)
-        {
-        }
+        public void setStackInSlot(int slot, ItemStack stack) {}
     }
 
-    public class ClientScrollInventory implements IItemHandlerModifiable
-    {
+    public class ClientScrollInventory implements IItemHandlerModifiable {
         private int[] indices;
         private NonNullList<ItemStack> stacks;
 
-        public ClientScrollInventory()
-        {
-        }
+        public ClientScrollInventory() {}
 
-        public void setArray(final NonNullList<ItemStack> stacks)
-        {
+        public void setArray(final NonNullList<ItemStack> stacks) {
             this.stacks = stacks;
 
             final List<Integer> indices = Lists.newArrayList();
@@ -767,78 +636,68 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
             final List<Component> itemData = Lists.newArrayList();
 
             int indexx = 0;
-            for (ItemStack invStack : stacks)
-            {
+            for (ItemStack invStack : stacks) {
                 ItemStack stack = invStack.copy();
 
                 boolean matchesSearch = true;
-                if (!Strings.isNullOrEmpty(filterText))
-                {
+                if (!Strings.isNullOrEmpty(filterText)) {
                     itemData.clear();
                     Item item = invStack.getItem();
                     itemData.add(stack.getHoverName());
                     itemData.add(Component.literal(ForgeRegistries.ITEMS.getKey(item).toString()));
                     item.appendHoverText(stack, player.level, itemData, TooltipFlag.Default.NORMAL);
                     matchesSearch = false;
-                    for (Component s : itemData)
-                    {
-                        if (StringUtils.containsIgnoreCase(s.getString(), filterText))
-                        {
+                    for (Component s : itemData) {
+                        if (StringUtils.containsIgnoreCase(s.getString(), filterText)) {
                             matchesSearch = true;
                             break;
                         }
                     }
                 }
 
-                if (matchesSearch)
-                {
+                if (matchesSearch) {
                     indices.add(indexx);
                 }
                 indexx++;
             }
 
-            if (sortMode != null)
-            {
-                switch (sortMode)
-                {
-                    case ALPHABETIC:
-                        indices.sort((ia, ib) ->
-                        {
-                            ItemStack a = stacks.get(ia);
-                            ItemStack b = stacks.get(ib);
-                            return a.getHoverName().getString().compareToIgnoreCase(b.getHoverName().getString());
-                        });
-                        break;
-                    case STACK_SIZE:
-                        indices.sort((ia, ib) ->
-                        {
-                            ItemStack a = stacks.get(ia);
-                            ItemStack b = stacks.get(ib);
-                            int diff = a.getCount() - b.getCount();
-                            if (diff > 0) return -1;
-                            if (diff < 0) return 1;
-                            return a.getHoverName().getString().compareToIgnoreCase(b.getHoverName().getString());
-                        });
-                        break;
+            if (sortMode != null) {
+                switch (sortMode) {
+                case ALPHABETIC:
+                    indices.sort((ia, ib) -> {
+                        ItemStack a = stacks.get(ia);
+                        ItemStack b = stacks.get(ib);
+                        return a.getHoverName().getString().compareToIgnoreCase(b.getHoverName().getString());
+                    });
+                    break;
+                case STACK_SIZE:
+                    indices.sort((ia, ib) -> {
+                        ItemStack a = stacks.get(ia);
+                        ItemStack b = stacks.get(ib);
+                        int diff = a.getCount() - b.getCount();
+                        if (diff > 0)
+                            return -1;
+                        if (diff < 0)
+                            return 1;
+                        return a.getHoverName().getString().compareToIgnoreCase(b.getHoverName().getString());
+                    });
+                    break;
                 }
             }
 
             this.indices = new int[indices.size()];
-            for (int i = 0; i < this.indices.length; i++)
-            {
+            for (int i = 0; i < this.indices.length; i++) {
                 this.indices[i] = indices.get(i);
             }
         }
 
         @Override
-        public int getSlots()
-        {
+        public int getSlots() {
             return indices.length;
         }
 
         @Override
-        public ItemStack getStackInSlot(int slot)
-        {
+        public ItemStack getStackInSlot(int slot) {
             if ((slot + scroll) >= indices.length)
                 return ItemStack.EMPTY;
             ItemStack stack = stacks.get(indices[slot + scroll]);
@@ -848,45 +707,38 @@ public class AbstractBrowserContainer extends AbstractContainerMenu
         }
 
         @Override
-        public ItemStack insertItem(int slot, ItemStack stack, boolean simulate)
-        {
+        public ItemStack insertItem(int slot, ItemStack stack, boolean simulate) {
             return ItemStack.EMPTY;
         }
 
         @Override
-        public ItemStack extractItem(int slot, int amount, boolean simulate)
-        {
+        public ItemStack extractItem(int slot, int amount, boolean simulate) {
             return ItemStack.EMPTY;
         }
 
         @Override
-        public int getSlotLimit(int slot)
-        {
+        public int getSlotLimit(int slot) {
             return 64;
         }
 
         @Override
-        public boolean isItemValid(int slot, @Nonnull ItemStack stack)
-        {
+        public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
             return true;
         }
 
         @Override
-        public void setStackInSlot(int slot, ItemStack stack)
-        {
+        public void setStackInSlot(int slot, ItemStack stack) {
             if ((slot + scroll) < indices.length)
                 stacks.set(indices[slot + scroll], stack);
         }
 
-        public int getStackSizeForSlot(int slot)
-        {
+        public int getStackSizeForSlot(int slot) {
             if ((slot + scroll) >= indices.length)
                 return 0;
             return stacks.get(indices[slot + scroll]).getCount();
         }
 
-        public int[] getIndices()
-        {
+        public int[] getIndices() {
             int from = Math.max(0, Math.min(scroll, indices.length - 1));
             int to = Math.min(from + SCROLL_SLOTS, indices.length);
             return Arrays.copyOfRange(indices, from, to);

--- a/src/main/java/dev/gigaherz/enderrift/automation/browser/AbstractBrowserContainer.java
+++ b/src/main/java/dev/gigaherz/enderrift/automation/browser/AbstractBrowserContainer.java
@@ -29,719 +29,849 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
-public class AbstractBrowserContainer extends AbstractContainerMenu {
-    protected final static int LEFT = 8;
-    protected final static int TOP = 18;
-    protected final static int SLOT_WIDTH = 18;
-    protected final static int SLOT_HEIGHT = 18;
-
-    protected final static int SCROLL_ROWS = 3;
-    protected final static int SCROLL_COLUMNS = 9;
-    protected final static int SCROLL_SLOTS = SCROLL_ROWS * SCROLL_COLUMNS;
-
-    protected final static int PLAYER_ROWS = 4;
-    protected final static int PLAYER_COLUMNS = 9;
-    protected final static int PLAYER_SLOTS = PLAYER_ROWS * PLAYER_COLUMNS;
-
-    private NonNullList<ItemStack> currentStacks = NonNullList.create();
-    private final Player player;
-    private int prevChangeCount;
-    private ItemStack stackInCursor = ItemStack.EMPTY;
-
-    @Nullable
-    protected BrowserBlockEntity tile;
-
-    public final IItemHandlerModifiable scrollInventory;
-    public int scroll;
-    public SortMode sortMode = SortMode.STACK_SIZE;
-    public String filterText = "";
-
-    private DataSlot isLowOnPower = new DataSlot() {
-        boolean value = false;
-
-        @Override
-        public int get() {
-            return (isClient() ? value : tile.isLowOnPower()) ? 1 : 0;
-        }
-
-        @Override
-        public void set(int value) {
-            this.value = value != 0;
-        }
-    };
-
-    public final boolean isClient() {
-        return tile == null;
-    }
-
-    public ClientScrollInventory getClient() {
-        if (!isClient())
-            throw new IllegalStateException("Attempted to get client inventory on the server");
-        return (ClientScrollInventory) scrollInventory;
-    }
-
-    public ServerScrollInventory getServer() {
-        if (isClient())
-            throw new IllegalStateException("Attempted to get server inventory on the client");
-        return (ServerScrollInventory) scrollInventory;
-    }
-
-    protected AbstractBrowserContainer(MenuType<? extends AbstractBrowserContainer> type, int id, @Nullable BrowserBlockEntity tileEntity,
-        Inventory playerInventory) {
-        super(type, id);
-
-        this.player = playerInventory.player;
-        boolean isClient = player.level.isClientSide;
-
-        if (isClient) {
-            this.tile = null;
-            scrollInventory = new ClientScrollInventory();
-        } else {
-            this.tile = Objects.requireNonNull(tileEntity);
-            scrollInventory = new ServerScrollInventory(tile);
-        }
-
-        for (int y = 0; y < SCROLL_ROWS; y++) {
-            for (int x = 0; x < SCROLL_COLUMNS; x++) {
-                addSlot(new SlotFake(scrollInventory, x + y * SCROLL_COLUMNS, LEFT + x * SLOT_WIDTH, TOP + y * SLOT_HEIGHT));
-            }
-        }
-
-        bindPlayerInventory(playerInventory);
-
-        addDataSlot(isLowOnPower);
-    }
-
-    protected void bindPlayerInventory(Inventory playerInventory) {
-        bindPlayerInventory(playerInventory, TOP + SCROLL_ROWS * SLOT_HEIGHT + 14);
-    }
-
-    protected void bindPlayerInventory(Inventory playerInventory, int top) {
-        for (int y = 0; y < 3; y++) {
-            for (int x = 0; x < 9; x++) {
-                addSlot(new Slot(playerInventory, x + y * 9 + 9, LEFT + x * SLOT_WIDTH, top + y * SLOT_HEIGHT));
-            }
-        }
-
-        top += 3 * SLOT_HEIGHT + 4;
-        for (int x = 0; x < 9; x++) {
-            addSlot(new Slot(playerInventory, x, LEFT + x * SLOT_WIDTH, top));
-        }
-    }
-
-    @Override
-    public boolean stillValid(Player player) {
-        return true;
-    }
-
-    @Override
-    public void broadcastChanges() {
-        if (isClient())
-            return;
-
-        ServerScrollInventory serverInv = getServer();
-        if (prevChangeCount != tile.getChangeCount()) {
-            serverInv.refresh();
-            prevChangeCount = tile.getChangeCount();
-        }
-
-        int oldLength = currentStacks.size();
-        int newLength;
-        List<Integer> indicesChanged = Lists.newArrayList();
-        List<ItemStack> stacksChanged = Lists.newArrayList();
-
-        newLength = serverInv.getRealSizeInventory();
-        if (newLength != oldLength) {
-            changeSize(oldLength, newLength);
-        }
-
-        for (int i = 0; i < newLength; ++i) {
-            ItemStack newStack = serverInv.getStack(i);
-            ItemStack current = currentStacks.get(i);
-
-            if (!ItemStack.matches(current, newStack)) {
-                current = newStack.copy();
-                currentStacks.set(i, current);
-
-                indicesChanged.add(i);
-                stacksChanged.add(current);
-            }
-        }
-
-        for (int i = SCROLL_SLOTS; i < this.slots.size(); ++i) {
-            ItemStack inSlot = slots.get(i).getItem();
-            ItemStack inCache = lastSlots.get(i);
-
-            if (!ItemStack.matches(inCache, inSlot)) {
-                inCache = inSlot.copy();
-                this.lastSlots.set(i, inCache);
-
-                for (ContainerListener crafter : this.containerListeners) {
-                    crafter.slotChanged(this, i, inCache);
-                }
-            }
-        }
-
-        if (player instanceof ServerPlayer crafter) {
-            if (newLength != oldLength || indicesChanged.size() > 0) {
-                EnderRiftMod.CHANNEL.sendTo(new SendSlotChanges(containerId, newLength, indicesChanged, stacksChanged),
-                    crafter.connection.getConnection(), NetworkDirection.PLAY_TO_CLIENT);
-            }
-
-            ItemStack newStack = getCarried();
-
-            if (!ItemStack.matches(stackInCursor, newStack)) {
-                sendStackInCursor(crafter, newStack);
-            }
-        }
-
-        if (newLength != oldLength || indicesChanged.size() > 0) {
-            serverInv.resetVisible();
-        }
-    }
-
-    private void changeSize(int oldLength, int newLength) {
-        NonNullList<ItemStack> oldStacks = currentStacks;
-        currentStacks = NonNullList.withSize(newLength, ItemStack.EMPTY);
-        for (int i = 0; i < Math.min(newLength, oldLength); i++) {
-            currentStacks.set(i, oldStacks.get(i));
-        }
-    }
-
-    private void sendStackInCursor(ServerPlayer player, ItemStack newStack) {
-        stackInCursor = newStack.copy();
-
-        player.connection.send(new ClientboundContainerSetSlotPacket(-1, incrementStateId(), -1, newStack));
-    }
-
-    public void slotsChanged(int slotCount, List<Integer> indices, List<ItemStack> stacks) {
-        if (slotCount != currentStacks.size()) {
-            changeSize(currentStacks.size(), slotCount);
-        }
-
-        for (int i = 0; i < indices.size(); i++) {
-            int slot = indices.get(i);
-            ItemStack stack = stacks.get(i);
-
-            currentStacks.set(slot, stack);
-        }
-
-        ClientScrollInventory clientInv = getClient();
-        clientInv.setArray(currentStacks);
-
-        setVisibleSlots(clientInv.getIndices());
-    }
-
-    @Override
-    public void initializeContents(int p_182411_, List<ItemStack> p_182412_, ItemStack p_182413_) {
-        super.initializeContents(p_182411_, List.of(), p_182413_);
-    }
-
-    public void setVisibleSlots(int[] visible) {
-        if (isClient()) {
-            EnderRiftMod.CHANNEL.sendToServer(new SetVisibleSlots(containerId, visible));
-        } else {
-            getServer().setVisible(visible);
-        }
-    }
-
-    public void setScrollPos(int scroll) {
-        this.scroll = scroll;
-
-        setVisibleSlots(getClient().getIndices());
-    }
-
-    public void setSortMode(SortMode sortMode) {
-        this.sortMode = sortMode;
-        this.scroll = 0;
-
-        ClientScrollInventory clientInv = getClient();
-        clientInv.setArray(currentStacks);
-
-        setVisibleSlots(clientInv.getIndices());
-    }
-
-    public void setFilterText(String text) {
-        this.filterText = text.toLowerCase();
-        this.scroll = 0;
-
-        ClientScrollInventory clientInv = getClient();
-        clientInv.setArray(currentStacks);
-
-        setVisibleSlots(clientInv.getIndices());
-    }
-
-    @Override
-    public void setItem(int slotID, int stateId, ItemStack stack) {
-        super.setItem(slotID, stateId, stack);
-    }
-
-    @Override
-    public void clicked(int slotId, int clickedButton, ClickType mode, Player playerIn) {
-        if (slotId >= 0 && slotId < SCROLL_SLOTS) {
-            IItemHandler parent = getTileInventory();
-
-            Slot slot = this.slots.get(slotId);
-            ItemStack existing = slot.getItem();
-            int existingSize = isClient() ? getClient().getStackSizeForSlot(slotId) : existing.getCount();
-
-            if (mode == ClickType.PICKUP) {
-                ItemStack dropping = getCarried();
-
-                if (dropping.getCount() > 0) {
-                    if (clickedButton == 0) {
-                        ItemStack remaining = insertItemsSided(parent, dropping);
-                        if (remaining.getCount() > 0) {
-                            if (dropping.getCount() != remaining.getCount())
-                                markTileDirty();
-
-                            if (player instanceof ServerPlayer crafter) {
-                                sendStackInCursor(crafter, remaining);
-                            }
-                        } else {
-                            markTileDirty();
-                        }
-                        setCarried(remaining);
-                    } else {
-                        int amount = 1;
-
-                        ItemStack push = dropping.copy();
-                        push.setCount(amount);
-                        ItemStack remaining = insertItemsSided(parent, push);
-
-                        dropping.shrink(push.getCount());
-
-                        if (remaining.getCount() > 0) {
-                            if (push.getCount() != remaining.getCount())
-                                markTileDirty();
-                            dropping.grow(remaining.getCount());
-
-                            if (player instanceof ServerPlayer crafter) {
-                                sendStackInCursor(crafter, remaining);
-                            }
-                        } else {
-                            markTileDirty();
-                        }
-
-                        if (dropping.getCount() <= 0)
-                            dropping = ItemStack.EMPTY;
-
-                        setCarried(dropping);
-                    }
-                } else if (existingSize > 0) {
-                    int amount = clickedButton == 0 ? existing.getMaxStackSize() : existing.getMaxStackSize() / 2;
-
-                    ItemStack extracted = extractItemsSided(parent, existing, existingSize, amount, false);
-                    if (extracted.getCount() > 0) {
-                        markTileDirty();
-                    } else {
-
-                        if (player instanceof ServerPlayer crafter) {
-                            sendStackInCursor(crafter, extracted);
-                        }
-                    }
-                    setCarried(extracted);
-                }
-
-                broadcastChanges();
-                return;
-            } else if (mode == ClickType.QUICK_MOVE && existingSize > 0) {
-                int amount = existing.getMaxStackSize();
-                if (clickedButton != 0 && amount > 1)
-                    amount /= 2;
-
-                if (amount == 0)
-                    return;
-
-                ItemStack remaining = simulateAddToPlayer(existing, amount);
-
-                if (remaining.getCount() > 0)
-                    amount -= remaining.getCount();
-
-                if (amount > 0) {
-                    ItemStack finalExtract = extractItemsSided(parent, existing, existingSize, amount, false);
-
-                    if (finalExtract.getCount() > 0) {
-                        addToPlayer(finalExtract);
-
-                        markTileDirty();
-                        broadcastChanges();
-                    }
-                }
-            }
-
-            if (mode != ClickType.CLONE)
-                return;
-        }
-
-        super.clicked(slotId, clickedButton, mode, playerIn);
-    }
-
-    @Nullable
-    private IItemHandler getTileInventory() {
-        return isClient() ? null : tile.getCombinedInventory();
-    }
-
-    private void markTileDirty() {
-        if (!isClient())
-            tile.setChanged();
-    }
-
-    private ItemStack extractItemsSided(@Nullable IItemHandler parent, ItemStack existing, int existingSize, int amount, boolean simulate) {
-        if (isClient() || parent == null) {
-            var copy = existing.copy();
-            copy.setCount(Math.min(existingSize, amount));
-            return copy;
-        }
-        return AutomationHelper.extractItems(parent, existing, amount, simulate);
-    }
-
-    private ItemStack insertItemsSided(@Nullable IItemHandler parent, ItemStack dropping) {
-        if (isClient() || parent == null)
-            return ItemStack.EMPTY;
-        return AutomationHelper.insertItems(parent, dropping);
-    }
-
-    private ItemStack simulateAddToPlayer(ItemStack stack, int amount) {
-        int startIndex = SCROLL_SLOTS;
-        int endIndex = startIndex + PLAYER_SLOTS;
-
-        ItemStack stackCopy = stack.copy();
-        stackCopy.setCount(amount);
-
-        if (!this.simulateInsertStack(stackCopy, startIndex, endIndex)) {
-            return stackCopy;
-        }
-
-        if (stackCopy.getCount() <= 0) {
-            return ItemStack.EMPTY;
-        }
-
-        return stackCopy;
-    }
-
-    protected boolean simulateInsertStack(ItemStack stack, int startIndex, int endIndex) {
-        boolean canInsert = false;
-
-        if (stack.isStackable()) {
-            for (int i = startIndex; stack.getCount() > 0 && i < endIndex; i++) {
-                Slot slot = this.slots.get(i);
-                ItemStack stackInSlot = slot.getItem();
-
-                if (stackInSlot.getCount() < stackInSlot.getMaxStackSize() && ItemStack.isSame(stackInSlot, stack)
-                    && ItemStack.tagMatches(stack, stackInSlot)) {
-                    int j = stackInSlot.getCount() + stack.getCount();
-
-                    if (j <= stack.getMaxStackSize()) {
-                        stack.setCount(0);
-                        canInsert = true;
-                    } else {
-                        stack.shrink(stack.getMaxStackSize() - stackInSlot.getCount());
-                        canInsert = true;
-                    }
-                }
-            }
-        }
-
-        if (stack.getCount() > 0) {
-            for (int i = startIndex; i < endIndex; i++) {
-                Slot slot = this.slots.get(i);
-                ItemStack stackInSlot = slot.getItem();
-
-                if (stackInSlot.getCount() <= 0 && slot.mayPlace(stack)) {
-                    stack.setCount(0);
-                    canInsert = true;
-                    break;
-                }
-            }
-        }
-
-        return canInsert;
-    }
-
-    public ItemStack addToPlayer(ItemStack stack) {
-        int startIndex = SCROLL_SLOTS;
-        int endIndex = startIndex + PLAYER_SLOTS;
-
-        ItemStack stackCopy = stack.copy();
-
-        if (!this.moveItemStackTo(stackCopy, startIndex, endIndex, false)) {
-            return stackCopy;
-        }
-
-        if (stackCopy.getCount() <= 0) {
-            return ItemStack.EMPTY;
-        }
-
-        return stackCopy;
-    }
-
-    @Override
-    public ItemStack quickMoveStack(Player player, int slotIndex) {
-        Slot slot = this.slots.get(slotIndex);
-
-        if (slot == null || !slot.hasItem()) {
-            return ItemStack.EMPTY;
-        }
-
-        if (slotIndex < SCROLL_SLOTS) {
-            // Shouldn't even happen, handled above.
-            return ItemStack.EMPTY;
-        } else {
-            ItemStack stack = slot.getItem();
-            ItemStack stackCopy = stack.copy();
-
-            ItemStack remaining = insertItemsSided(getTileInventory(), stack);
-            if (remaining.getCount() > 0) {
-                if (player instanceof ContainerListener) {
-                    ((ContainerListener) player).slotChanged(this, slotIndex, remaining);
-                }
-
-                if (remaining.getCount() == stackCopy.getCount()) {
-                    return ItemStack.EMPTY;
-                }
-
-                markTileDirty();
-                stack.setCount(remaining.getCount());
-                slot.setChanged();
-            } else {
-                markTileDirty();
-                stack.setCount(0);
-                slot.set(ItemStack.EMPTY);
-            }
-
-            slot.onTake(player, stack);
-            return stackCopy;
-        }
-    }
-
-    public int getActualSlotCount() {
-        return scrollInventory.getSlots();
-    }
-
-    public boolean isLowOnPower() {
-        return isLowOnPower.get() != 0;
-    }
-
-    public static class ServerScrollInventory implements IItemHandlerModifiable {
-        final BrowserBlockEntity tile;
-        final List<ItemStack> slots = Lists.newArrayList();
-        private int[] visible = new int[0];
-
-        public ServerScrollInventory(BrowserBlockEntity tile) {
-            this.tile = tile;
-        }
-
-        public void setVisible(int[] visible) {
-            this.visible = visible;
-        }
-
-        public void resetVisible() {
-            visible = new int[0];
-        }
-
-        public void refresh() {
-            IItemHandler inv = tile.getCombinedInventory();
-
-            final List<ItemStack> slotsSeen = Lists.newArrayList();
-
-            slots.clear();
-
-            if (inv == null)
-                return;
-
-            int invSlots = inv.getSlots();
-            for (int j = 0; j < invSlots; j++) {
-                ItemStack invStack = inv.getStackInSlot(j);
-                if (invStack.getCount() <= 0)
-                    continue;
-
-                boolean found = false;
-
-                for (ItemStack cachedStack : slotsSeen) {
-                    if (ItemStack.isSame(cachedStack, invStack) && ItemStack.tagMatches(cachedStack, invStack)) {
-                        cachedStack.grow(invStack.getCount());
-                        found = true;
-                        break;
-                    }
-                }
-
-                if (!found) {
-                    ItemStack stack = invStack.copy();
-                    slotsSeen.add(stack);
-
-                    slots.add(stack);
-                }
-            }
-        }
-
-        public int getRealSizeInventory() {
-            return slots.size();
-        }
-
-        @Override
-        public int getSlots() {
-            return visible.length;
-        }
-
-        @Override
-        public ItemStack getStackInSlot(int index) {
-            if (index >= visible.length)
-                return ItemStack.EMPTY;
-            int i = visible[index];
-            if (i >= slots.size())
-                return ItemStack.EMPTY;
-            return slots.get(visible[index]);
-        }
-
-        public ItemStack getStack(int index) {
-            return slots.get(index);
-        }
-
-        @Override
-        public ItemStack insertItem(int slot, ItemStack stack, boolean simulate) {
-            return ItemStack.EMPTY;
-        }
-
-        @Override
-        public ItemStack extractItem(int slot, int amount, boolean simulate) {
-            return ItemStack.EMPTY;
-        }
-
-        @Override
-        public int getSlotLimit(int slot) {
-            return 64;
-        }
-
-        @Override
-        public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
-            return true;
-        }
-
-        @Override
-        public void setStackInSlot(int slot, ItemStack stack) {}
-    }
-
-    public class ClientScrollInventory implements IItemHandlerModifiable {
-        private int[] indices;
-        private NonNullList<ItemStack> stacks;
-
-        public ClientScrollInventory() {}
-
-        public void setArray(final NonNullList<ItemStack> stacks) {
-            this.stacks = stacks;
-
-            final List<Integer> indices = Lists.newArrayList();
-
-            final List<Component> itemData = Lists.newArrayList();
-
-            int indexx = 0;
-            for (ItemStack invStack : stacks) {
-                ItemStack stack = invStack.copy();
-
-                boolean matchesSearch = true;
-                if (!Strings.isNullOrEmpty(filterText)) {
-                    itemData.clear();
-                    Item item = invStack.getItem();
-                    itemData.add(stack.getHoverName());
-                    itemData.add(Component.literal(ForgeRegistries.ITEMS.getKey(item).toString()));
-                    item.appendHoverText(stack, player.level, itemData, TooltipFlag.Default.NORMAL);
-                    matchesSearch = false;
-                    for (Component s : itemData) {
-                        if (StringUtils.containsIgnoreCase(s.getString(), filterText)) {
-                            matchesSearch = true;
-                            break;
-                        }
-                    }
-                }
-
-                if (matchesSearch) {
-                    indices.add(indexx);
-                }
-                indexx++;
-            }
-
-            if (sortMode != null) {
-                switch (sortMode) {
-                case ALPHABETIC:
-                    indices.sort((ia, ib) -> {
-                        ItemStack a = stacks.get(ia);
-                        ItemStack b = stacks.get(ib);
-                        return a.getHoverName().getString().compareToIgnoreCase(b.getHoverName().getString());
-                    });
-                    break;
-                case STACK_SIZE:
-                    indices.sort((ia, ib) -> {
-                        ItemStack a = stacks.get(ia);
-                        ItemStack b = stacks.get(ib);
-                        int diff = a.getCount() - b.getCount();
-                        if (diff > 0)
-                            return -1;
-                        if (diff < 0)
-                            return 1;
-                        return a.getHoverName().getString().compareToIgnoreCase(b.getHoverName().getString());
-                    });
-                    break;
-                }
-            }
-
-            this.indices = new int[indices.size()];
-            for (int i = 0; i < this.indices.length; i++) {
-                this.indices[i] = indices.get(i);
-            }
-        }
-
-        @Override
-        public int getSlots() {
-            return indices.length;
-        }
-
-        @Override
-        public ItemStack getStackInSlot(int slot) {
-            if ((slot + scroll) >= indices.length)
-                return ItemStack.EMPTY;
-            ItemStack stack = stacks.get(indices[slot + scroll]);
-            stack = stack.copy();
-            stack.setCount(1);
-            return stack;
-        }
-
-        @Override
-        public ItemStack insertItem(int slot, ItemStack stack, boolean simulate) {
-            return ItemStack.EMPTY;
-        }
-
-        @Override
-        public ItemStack extractItem(int slot, int amount, boolean simulate) {
-            return ItemStack.EMPTY;
-        }
-
-        @Override
-        public int getSlotLimit(int slot) {
-            return 64;
-        }
-
-        @Override
-        public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
-            return true;
-        }
-
-        @Override
-        public void setStackInSlot(int slot, ItemStack stack) {
-            if ((slot + scroll) < indices.length)
-                stacks.set(indices[slot + scroll], stack);
-        }
-
-        public int getStackSizeForSlot(int slot) {
-            if ((slot + scroll) >= indices.length)
-                return 0;
-            return stacks.get(indices[slot + scroll]).getCount();
-        }
-
-        public int[] getIndices() {
-            int from = Math.max(0, Math.min(scroll, indices.length - 1));
-            int to = Math.min(from + SCROLL_SLOTS, indices.length);
-            return Arrays.copyOfRange(indices, from, to);
-        }
-    }
+public class AbstractBrowserContainer extends AbstractContainerMenu
+{
+	protected final static int LEFT = 8;
+	protected final static int TOP = 18;
+	protected final static int SLOT_WIDTH = 18;
+	protected final static int SLOT_HEIGHT = 18;
+
+	protected final static int SCROLL_ROWS = 3;
+	protected final static int SCROLL_COLUMNS = 9;
+	protected final static int SCROLL_SLOTS = SCROLL_ROWS * SCROLL_COLUMNS;
+
+	protected final static int PLAYER_ROWS = 4;
+	protected final static int PLAYER_COLUMNS = 9;
+	protected final static int PLAYER_SLOTS = PLAYER_ROWS * PLAYER_COLUMNS;
+
+	private NonNullList<ItemStack> currentStacks = NonNullList.create();
+	private final Player player;
+	private int prevChangeCount;
+	private ItemStack stackInCursor = ItemStack.EMPTY;
+
+	@Nullable
+	protected BrowserBlockEntity tile;
+
+	public final IItemHandlerModifiable scrollInventory;
+	public int scroll;
+	public SortMode sortMode = SortMode.STACK_SIZE;
+	public String filterText = "";
+
+	private DataSlot isLowOnPower = new DataSlot()
+	{
+		boolean value = false;
+
+		@Override
+		public int get()
+		{
+			return (isClient() ? value : tile.isLowOnPower()) ? 1 : 0;
+		}
+
+		@Override
+		public void set(int value)
+		{
+			this.value = value != 0;
+		}
+	};
+
+	public final boolean isClient()
+	{
+		return tile == null;
+	}
+
+	public ClientScrollInventory getClient()
+	{
+		if (!isClient())
+			throw new IllegalStateException("Attempted to get client inventory on the server");
+		return (ClientScrollInventory) scrollInventory;
+	}
+
+	public ServerScrollInventory getServer()
+	{
+		if (isClient())
+			throw new IllegalStateException("Attempted to get server inventory on the client");
+		return (ServerScrollInventory) scrollInventory;
+	}
+
+	protected AbstractBrowserContainer(MenuType<? extends AbstractBrowserContainer> type, int id, @Nullable BrowserBlockEntity tileEntity, Inventory playerInventory)
+	{
+		super(type, id);
+
+		this.player = playerInventory.player;
+		boolean isClient = player.level.isClientSide;
+
+		if (isClient)
+		{
+			this.tile = null;
+			scrollInventory = new ClientScrollInventory();
+		} else
+		{
+			this.tile = Objects.requireNonNull(tileEntity);
+			scrollInventory = new ServerScrollInventory(tile);
+		}
+
+		for (int y = 0; y < SCROLL_ROWS; y++)
+		{
+			for (int x = 0; x < SCROLL_COLUMNS; x++)
+			{
+				addSlot(new SlotFake(scrollInventory, x + y * SCROLL_COLUMNS, LEFT + x * SLOT_WIDTH, TOP + y * SLOT_HEIGHT));
+			}
+		}
+
+		bindPlayerInventory(playerInventory);
+
+		addDataSlot(isLowOnPower);
+	}
+
+	protected void bindPlayerInventory(Inventory playerInventory)
+	{
+		bindPlayerInventory(playerInventory, TOP + SCROLL_ROWS * SLOT_HEIGHT + 14);
+	}
+
+	protected void bindPlayerInventory(Inventory playerInventory, int top)
+	{
+		for (int y = 0; y < 3; y++)
+		{
+			for (int x = 0; x < 9; x++)
+			{
+				addSlot(new Slot(playerInventory, x + y * 9 + 9, LEFT + x * SLOT_WIDTH, top + y * SLOT_HEIGHT));
+			}
+		}
+
+		top += 3 * SLOT_HEIGHT + 4;
+		for (int x = 0; x < 9; x++)
+		{
+			addSlot(new Slot(playerInventory, x, LEFT + x * SLOT_WIDTH, top));
+		}
+	}
+
+	@Override
+	public boolean stillValid(Player player)
+	{
+		return true;
+	}
+
+	@Override
+	public void broadcastChanges()
+	{
+		if (isClient())
+			return;
+
+		ServerScrollInventory serverInv = getServer();
+		if (prevChangeCount != tile.getChangeCount())
+		{
+			serverInv.refresh();
+			prevChangeCount = tile.getChangeCount();
+		}
+
+		int oldLength = currentStacks.size();
+		int newLength;
+		List<Integer> indicesChanged = Lists.newArrayList();
+		List<ItemStack> stacksChanged = Lists.newArrayList();
+
+		newLength = serverInv.getRealSizeInventory();
+		if (newLength != oldLength)
+		{
+			changeSize(oldLength, newLength);
+		}
+
+		for (int i = 0; i < newLength; ++i)
+		{
+			ItemStack newStack = serverInv.getStack(i);
+			ItemStack current = currentStacks.get(i);
+
+			if (!ItemStack.matches(current, newStack))
+			{
+				current = newStack.copy();
+				currentStacks.set(i, current);
+
+				indicesChanged.add(i);
+				stacksChanged.add(current);
+			}
+		}
+
+		for (int i = SCROLL_SLOTS; i < this.slots.size(); ++i)
+		{
+			ItemStack inSlot = slots.get(i).getItem();
+			ItemStack inCache = lastSlots.get(i);
+
+			if (!ItemStack.matches(inCache, inSlot))
+			{
+				inCache = inSlot.copy();
+				this.lastSlots.set(i, inCache);
+
+				for (ContainerListener crafter : this.containerListeners)
+				{
+					crafter.slotChanged(this, i, inCache);
+				}
+			}
+		}
+
+		if (player instanceof ServerPlayer crafter)
+		{
+			if (newLength != oldLength || indicesChanged.size() > 0)
+			{
+				EnderRiftMod.CHANNEL.sendTo(new SendSlotChanges(containerId, newLength, indicesChanged, stacksChanged), crafter.connection.getConnection(), NetworkDirection.PLAY_TO_CLIENT);
+			}
+
+			ItemStack newStack = getCarried();
+
+			if (!ItemStack.matches(stackInCursor, newStack))
+			{
+				sendStackInCursor(crafter, newStack);
+			}
+		}
+
+		if (newLength != oldLength || indicesChanged.size() > 0)
+		{
+			serverInv.resetVisible();
+		}
+	}
+
+	private void changeSize(int oldLength, int newLength)
+	{
+		NonNullList<ItemStack> oldStacks = currentStacks;
+		currentStacks = NonNullList.withSize(newLength, ItemStack.EMPTY);
+		for (int i = 0; i < Math.min(newLength, oldLength); i++)
+		{
+			currentStacks.set(i, oldStacks.get(i));
+		}
+	}
+
+	private void sendStackInCursor(ServerPlayer player, ItemStack newStack)
+	{
+		stackInCursor = newStack.copy();
+
+		player.connection.send(new ClientboundContainerSetSlotPacket(-1, incrementStateId(), -1, newStack));
+	}
+
+	public void slotsChanged(int slotCount, List<Integer> indices, List<ItemStack> stacks)
+	{
+		if (slotCount != currentStacks.size())
+		{
+			changeSize(currentStacks.size(), slotCount);
+		}
+
+		for (int i = 0; i < indices.size(); i++)
+		{
+			int slot = indices.get(i);
+			ItemStack stack = stacks.get(i);
+
+			currentStacks.set(slot, stack);
+		}
+
+		ClientScrollInventory clientInv = getClient();
+		clientInv.setArray(currentStacks);
+
+		setVisibleSlots(clientInv.getIndices());
+	}
+
+	@Override
+	public void initializeContents(int p_182411_, List<ItemStack> p_182412_, ItemStack p_182413_)
+	{
+		super.initializeContents(p_182411_, List.of(), p_182413_);
+	}
+
+	public void setVisibleSlots(int[] visible)
+	{
+		if (isClient())
+		{
+			EnderRiftMod.CHANNEL.sendToServer(new SetVisibleSlots(containerId, visible));
+		} else
+		{
+			getServer().setVisible(visible);
+		}
+	}
+
+	public void setScrollPos(int scroll)
+	{
+		this.scroll = scroll;
+
+		setVisibleSlots(getClient().getIndices());
+	}
+
+	public void setSortMode(SortMode sortMode)
+	{
+		this.sortMode = sortMode;
+		this.scroll = 0;
+
+		ClientScrollInventory clientInv = getClient();
+		clientInv.setArray(currentStacks);
+
+		setVisibleSlots(clientInv.getIndices());
+	}
+
+	public void setFilterText(String text)
+	{
+		this.filterText = text.toLowerCase();
+		this.scroll = 0;
+
+		ClientScrollInventory clientInv = getClient();
+		clientInv.setArray(currentStacks);
+
+		setVisibleSlots(clientInv.getIndices());
+	}
+
+	@Override
+	public void setItem(int slotID, int stateId, ItemStack stack)
+	{
+		super.setItem(slotID, stateId, stack);
+	}
+
+	@Override
+	public void clicked(int slotId, int clickedButton, ClickType mode, Player playerIn)
+	{
+		if (slotId >= 0 && slotId < SCROLL_SLOTS)
+		{
+			IItemHandler parent = getTileInventory();
+
+			Slot slot = this.slots.get(slotId);
+			ItemStack existing = slot.getItem();
+			int existingSize = isClient() ? getClient().getStackSizeForSlot(slotId) : existing.getCount();
+
+			if (mode == ClickType.PICKUP)
+			{
+				ItemStack dropping = getCarried();
+
+				if (dropping.getCount() > 0)
+				{
+					if (clickedButton == 0)
+					{
+						ItemStack remaining = insertItemsSided(parent, dropping);
+						if (remaining.getCount() > 0)
+						{
+							if (dropping.getCount() != remaining.getCount())
+								markTileDirty();
+
+							if (player instanceof ServerPlayer crafter)
+							{
+								sendStackInCursor(crafter, remaining);
+							}
+						} else
+						{
+							markTileDirty();
+						}
+						setCarried(remaining);
+					} else
+					{
+						int amount = 1;
+
+						ItemStack push = dropping.copy();
+						push.setCount(amount);
+						ItemStack remaining = insertItemsSided(parent, push);
+
+						dropping.shrink(push.getCount());
+
+						if (remaining.getCount() > 0)
+						{
+							if (push.getCount() != remaining.getCount())
+								markTileDirty();
+							dropping.grow(remaining.getCount());
+
+							if (player instanceof ServerPlayer crafter)
+							{
+								sendStackInCursor(crafter, remaining);
+							}
+						} else
+						{
+							markTileDirty();
+						}
+
+						if (dropping.getCount() <= 0)
+							dropping = ItemStack.EMPTY;
+
+						setCarried(dropping);
+					}
+				} else if (existingSize > 0)
+				{
+					int amount = clickedButton == 0 ? existing.getMaxStackSize() : existing.getMaxStackSize() / 2;
+
+					ItemStack extracted = extractItemsSided(parent, existing, existingSize, amount, false);
+					if (extracted.getCount() > 0)
+					{
+						markTileDirty();
+					} else
+					{
+
+						if (player instanceof ServerPlayer crafter)
+						{
+							sendStackInCursor(crafter, extracted);
+						}
+					}
+					setCarried(extracted);
+				}
+
+				broadcastChanges();
+				return;
+			} else if (mode == ClickType.QUICK_MOVE && existingSize > 0)
+			{
+				int amount = existing.getMaxStackSize();
+				if (clickedButton != 0 && amount > 1)
+					amount /= 2;
+
+				if (amount == 0)
+					return;
+
+				ItemStack remaining = simulateAddToPlayer(existing, amount);
+
+				if (remaining.getCount() > 0)
+					amount -= remaining.getCount();
+
+				if (amount > 0)
+				{
+					ItemStack finalExtract = extractItemsSided(parent, existing, existingSize, amount, false);
+
+					if (finalExtract.getCount() > 0)
+					{
+						addToPlayer(finalExtract);
+
+						markTileDirty();
+						broadcastChanges();
+					}
+				}
+			}
+
+			if (mode != ClickType.CLONE)
+				return;
+		}
+
+		super.clicked(slotId, clickedButton, mode, playerIn);
+	}
+
+	@Nullable
+	private IItemHandler getTileInventory()
+	{
+		return isClient() ? null : tile.getCombinedInventory();
+	}
+
+	private void markTileDirty()
+	{
+		if (!isClient())
+			tile.setChanged();
+	}
+
+	private ItemStack extractItemsSided(@Nullable IItemHandler parent, ItemStack existing, int existingSize, int amount, boolean simulate)
+	{
+		if (isClient() || parent == null)
+		{
+			var copy = existing.copy();
+			copy.setCount(Math.min(existingSize, amount));
+			return copy;
+		}
+		return AutomationHelper.extractItems(parent, existing, amount, simulate);
+	}
+
+	private ItemStack insertItemsSided(@Nullable IItemHandler parent, ItemStack dropping)
+	{
+		if (isClient() || parent == null)
+			return ItemStack.EMPTY;
+		return AutomationHelper.insertItems(parent, dropping);
+	}
+
+	private ItemStack simulateAddToPlayer(ItemStack stack, int amount)
+	{
+		int startIndex = SCROLL_SLOTS;
+		int endIndex = startIndex + PLAYER_SLOTS;
+
+		ItemStack stackCopy = stack.copy();
+		stackCopy.setCount(amount);
+
+		if (!this.simulateInsertStack(stackCopy, startIndex, endIndex))
+		{
+			return stackCopy;
+		}
+
+		if (stackCopy.getCount() <= 0)
+		{
+			return ItemStack.EMPTY;
+		}
+
+		return stackCopy;
+	}
+
+	protected boolean simulateInsertStack(ItemStack stack, int startIndex, int endIndex)
+	{
+		boolean canInsert = false;
+
+		if (stack.isStackable())
+		{
+			for (int i = startIndex; stack.getCount() > 0 && i < endIndex; i++)
+			{
+				Slot slot = this.slots.get(i);
+				ItemStack stackInSlot = slot.getItem();
+
+				if (stackInSlot.getCount() < stackInSlot.getMaxStackSize() && ItemStack.isSame(stackInSlot, stack) && ItemStack.tagMatches(stack, stackInSlot))
+				{
+					int j = stackInSlot.getCount() + stack.getCount();
+
+					if (j <= stack.getMaxStackSize())
+					{
+						stack.setCount(0);
+						canInsert = true;
+					} else
+					{
+						stack.shrink(stack.getMaxStackSize() - stackInSlot.getCount());
+						canInsert = true;
+					}
+				}
+			}
+		}
+
+		if (stack.getCount() > 0)
+		{
+			for (int i = startIndex; i < endIndex; i++)
+			{
+				Slot slot = this.slots.get(i);
+				ItemStack stackInSlot = slot.getItem();
+
+				if (stackInSlot.getCount() <= 0 && slot.mayPlace(stack))
+				{
+					stack.setCount(0);
+					canInsert = true;
+					break;
+				}
+			}
+		}
+
+		return canInsert;
+	}
+
+	public ItemStack addToPlayer(ItemStack stack)
+	{
+		int startIndex = SCROLL_SLOTS;
+		int endIndex = startIndex + PLAYER_SLOTS;
+
+		ItemStack stackCopy = stack.copy();
+
+		if (!this.moveItemStackTo(stackCopy, startIndex, endIndex, false))
+		{
+			return stackCopy;
+		}
+
+		if (stackCopy.getCount() <= 0)
+		{
+			return ItemStack.EMPTY;
+		}
+
+		return stackCopy;
+	}
+
+	@Override
+	public ItemStack quickMoveStack(Player player, int slotIndex)
+	{
+		Slot slot = this.slots.get(slotIndex);
+
+		if (slot == null || !slot.hasItem())
+		{
+			return ItemStack.EMPTY;
+		}
+
+		if (slotIndex < SCROLL_SLOTS)
+		{
+			// Shouldn't even happen, handled above.
+			return ItemStack.EMPTY;
+		} else
+		{
+			ItemStack stack = slot.getItem();
+			ItemStack stackCopy = stack.copy();
+
+			ItemStack remaining = insertItemsSided(getTileInventory(), stack);
+			if (remaining.getCount() > 0)
+			{
+				if (player instanceof ContainerListener)
+				{
+					((ContainerListener) player).slotChanged(this, slotIndex, remaining);
+				}
+
+				if (remaining.getCount() == stackCopy.getCount())
+				{
+					return ItemStack.EMPTY;
+				}
+
+				markTileDirty();
+				stack.setCount(remaining.getCount());
+				slot.setChanged();
+			} else
+			{
+				markTileDirty();
+				stack.setCount(0);
+				slot.set(ItemStack.EMPTY);
+			}
+
+			slot.onTake(player, stack);
+			return stackCopy;
+		}
+	}
+
+	public int getActualSlotCount()
+	{
+		return scrollInventory.getSlots();
+	}
+
+	public boolean isLowOnPower()
+	{
+		return isLowOnPower.get() != 0;
+	}
+
+	public static class ServerScrollInventory implements IItemHandlerModifiable
+	{
+		final BrowserBlockEntity tile;
+		final List<ItemStack> slots = Lists.newArrayList();
+		private int[] visible = new int[0];
+
+		public ServerScrollInventory(BrowserBlockEntity tile)
+		{
+			this.tile = tile;
+		}
+
+		public void setVisible(int[] visible)
+		{
+			this.visible = visible;
+		}
+
+		public void resetVisible()
+		{
+			visible = new int[0];
+		}
+
+		public void refresh()
+		{
+			IItemHandler inv = tile.getCombinedInventory();
+
+			final List<ItemStack> slotsSeen = Lists.newArrayList();
+
+			slots.clear();
+
+			if (inv == null)
+				return;
+
+			int invSlots = inv.getSlots();
+			for (int j = 0; j < invSlots; j++)
+			{
+				ItemStack invStack = inv.getStackInSlot(j);
+				if (invStack.getCount() <= 0)
+					continue;
+
+				boolean found = false;
+
+				for (ItemStack cachedStack : slotsSeen)
+				{
+					if (ItemStack.isSame(cachedStack, invStack) && ItemStack.tagMatches(cachedStack, invStack))
+					{
+						cachedStack.grow(invStack.getCount());
+						found = true;
+						break;
+					}
+				}
+
+				if (!found)
+				{
+					ItemStack stack = invStack.copy();
+					slotsSeen.add(stack);
+
+					slots.add(stack);
+				}
+			}
+		}
+
+		public int getRealSizeInventory()
+		{
+			return slots.size();
+		}
+
+		@Override
+		public int getSlots()
+		{
+			return visible.length;
+		}
+
+		@Override
+		public ItemStack getStackInSlot(int index)
+		{
+			if (index >= visible.length)
+				return ItemStack.EMPTY;
+			int i = visible[index];
+			if (i >= slots.size())
+				return ItemStack.EMPTY;
+			return slots.get(visible[index]);
+		}
+
+		public ItemStack getStack(int index)
+		{
+			return slots.get(index);
+		}
+
+		@Override
+		public ItemStack insertItem(int slot, ItemStack stack, boolean simulate)
+		{
+			return ItemStack.EMPTY;
+		}
+
+		@Override
+		public ItemStack extractItem(int slot, int amount, boolean simulate)
+		{
+			return ItemStack.EMPTY;
+		}
+
+		@Override
+		public int getSlotLimit(int slot)
+		{
+			return 64;
+		}
+
+		@Override
+		public boolean isItemValid(int slot, @Nonnull ItemStack stack)
+		{
+			return true;
+		}
+
+		@Override
+		public void setStackInSlot(int slot, ItemStack stack)
+		{
+		}
+	}
+
+	public class ClientScrollInventory implements IItemHandlerModifiable
+	{
+		private int[] indices;
+		private NonNullList<ItemStack> stacks;
+
+		public ClientScrollInventory()
+		{
+		}
+
+		public void setArray(final NonNullList<ItemStack> stacks)
+		{
+			this.stacks = stacks;
+
+			final List<Integer> indices = Lists.newArrayList();
+
+			final List<Component> itemData = Lists.newArrayList();
+
+			int indexx = 0;
+			for (ItemStack invStack : stacks)
+			{
+				ItemStack stack = invStack.copy();
+
+				boolean matchesSearch = true;
+				if (!Strings.isNullOrEmpty(filterText))
+				{
+					itemData.clear();
+					Item item = invStack.getItem();
+					itemData.add(stack.getHoverName());
+					itemData.add(Component.literal(ForgeRegistries.ITEMS.getKey(item).toString()));
+					item.appendHoverText(stack, player.level, itemData, TooltipFlag.Default.NORMAL);
+					matchesSearch = false;
+					for (Component s : itemData)
+					{
+						if (StringUtils.containsIgnoreCase(s.getString(), filterText))
+						{
+							matchesSearch = true;
+							break;
+						}
+					}
+				}
+
+				if (matchesSearch)
+				{
+					indices.add(indexx);
+				}
+				indexx++;
+			}
+
+			if (sortMode != null)
+			{
+				switch (sortMode)
+				{
+				case ALPHABETIC:
+					indices.sort((ia, ib) -> {
+						ItemStack a = stacks.get(ia);
+						ItemStack b = stacks.get(ib);
+						return a.getHoverName().getString().compareToIgnoreCase(b.getHoverName().getString());
+					});
+					break;
+				case STACK_SIZE:
+					indices.sort((ia, ib) -> {
+						ItemStack a = stacks.get(ia);
+						ItemStack b = stacks.get(ib);
+						int diff = a.getCount() - b.getCount();
+						if (diff > 0)
+							return -1;
+						if (diff < 0)
+							return 1;
+						return a.getHoverName().getString().compareToIgnoreCase(b.getHoverName().getString());
+					});
+					break;
+				}
+			}
+
+			this.indices = new int[indices.size()];
+			for (int i = 0; i < this.indices.length; i++)
+			{
+				this.indices[i] = indices.get(i);
+			}
+		}
+
+		@Override
+		public int getSlots()
+		{
+			return indices.length;
+		}
+
+		@Override
+		public ItemStack getStackInSlot(int slot)
+		{
+			if ((slot + scroll) >= indices.length)
+				return ItemStack.EMPTY;
+			ItemStack stack = stacks.get(indices[slot + scroll]);
+			stack = stack.copy();
+			stack.setCount(1);
+			return stack;
+		}
+
+		@Override
+		public ItemStack insertItem(int slot, ItemStack stack, boolean simulate)
+		{
+			return ItemStack.EMPTY;
+		}
+
+		@Override
+		public ItemStack extractItem(int slot, int amount, boolean simulate)
+		{
+			return ItemStack.EMPTY;
+		}
+
+		@Override
+		public int getSlotLimit(int slot)
+		{
+			return 64;
+		}
+
+		@Override
+		public boolean isItemValid(int slot, @Nonnull ItemStack stack)
+		{
+			return true;
+		}
+
+		@Override
+		public void setStackInSlot(int slot, ItemStack stack)
+		{
+			if ((slot + scroll) < indices.length)
+				stacks.set(indices[slot + scroll], stack);
+		}
+
+		public int getStackSizeForSlot(int slot)
+		{
+			if ((slot + scroll) >= indices.length)
+				return 0;
+			return stacks.get(indices[slot + scroll]).getCount();
+		}
+
+		public int[] getIndices()
+		{
+			int from = Math.max(0, Math.min(scroll, indices.length - 1));
+			int to = Math.min(from + SCROLL_SLOTS, indices.length);
+			return Arrays.copyOfRange(indices, from, to);
+		}
+	}
 }

--- a/src/main/java/dev/gigaherz/enderrift/debug/DebugItemBlock.java
+++ b/src/main/java/dev/gigaherz/enderrift/debug/DebugItemBlock.java
@@ -1,24 +1,23 @@
 package dev.gigaherz.enderrift.debug;
 
 import com.google.common.collect.Lists;
-import dev.gigaherz.enderrift.EnderRiftMod;
-import dev.gigaherz.enderrift.rift.RiftBlockEntity;
+
+import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.BaseEntityBlock;
-import net.minecraft.world.level.block.entity.BlockEntityTicker;
-import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.level.storage.loot.LootContext;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.VoxelShape;
 
 import java.util.List;
 
-import org.jetbrains.annotations.Nullable;
-
 public class DebugItemBlock extends BaseEntityBlock
 {
+    private static final VoxelShape SHAPE = Block.box(4, 4, 4, 12, 12, 12);
 
     public DebugItemBlock(Properties properties)
     {
@@ -32,18 +31,17 @@ public class DebugItemBlock extends BaseEntityBlock
         return new DebugItemBlockEntity(pos, state);
     }
 
-    @Nullable
-    @Override
-    public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level pLevel, BlockState pState, BlockEntityType<T> pBlockEntityType)
-    {
-        return BaseEntityBlock.createTickerHelper(pBlockEntityType, EnderRiftMod.RIFT_BLOCK_ENTITY.get(), RiftBlockEntity::tickStatic);
-    }
-
     @Deprecated
     @Override
     public List<ItemStack> getDrops(BlockState state, LootContext.Builder builder)
     {
         return Lists.newArrayList(new ItemStack(this));
+    }
+    
+    @Override
+    public VoxelShape getShape(BlockState state, BlockGetter world, BlockPos pos, CollisionContext ctx)
+    {
+        return SHAPE;
     }
 
 }

--- a/src/main/java/dev/gigaherz/enderrift/debug/DebugItemBlock.java
+++ b/src/main/java/dev/gigaherz/enderrift/debug/DebugItemBlock.java
@@ -1,0 +1,44 @@
+package dev.gigaherz.enderrift.debug;
+
+import com.google.common.collect.Lists;
+import dev.gigaherz.enderrift.EnderRiftMod;
+import dev.gigaherz.enderrift.rift.RiftBlockEntity;
+import net.minecraft.world.level.block.BaseEntityBlock;
+import net.minecraft.world.level.block.entity.BlockEntityTicker;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.storage.loot.LootContext;
+
+import java.util.List;
+
+import org.jetbrains.annotations.Nullable;
+
+public class DebugItemBlock extends BaseEntityBlock {
+
+    public DebugItemBlock(Properties properties) {
+        super(properties);
+    }
+
+    @org.jetbrains.annotations.Nullable
+    @Override
+    public BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
+        return new DebugItemBlockEntity(pos, state);
+    }
+
+    @Nullable
+    @Override
+    public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level pLevel, BlockState pState, BlockEntityType<T> pBlockEntityType) {
+        return BaseEntityBlock.createTickerHelper(pBlockEntityType, EnderRiftMod.RIFT_BLOCK_ENTITY.get(), RiftBlockEntity::tickStatic);
+    }
+
+    @Deprecated
+    @Override
+    public List<ItemStack> getDrops(BlockState state, LootContext.Builder builder) {
+        return Lists.newArrayList(new ItemStack(this));
+    }
+
+}

--- a/src/main/java/dev/gigaherz/enderrift/debug/DebugItemBlock.java
+++ b/src/main/java/dev/gigaherz/enderrift/debug/DebugItemBlock.java
@@ -17,28 +17,33 @@ import java.util.List;
 
 import org.jetbrains.annotations.Nullable;
 
-public class DebugItemBlock extends BaseEntityBlock {
+public class DebugItemBlock extends BaseEntityBlock
+{
 
-    public DebugItemBlock(Properties properties) {
-        super(properties);
-    }
+	public DebugItemBlock(Properties properties)
+	{
+		super(properties);
+	}
 
-    @org.jetbrains.annotations.Nullable
-    @Override
-    public BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
-        return new DebugItemBlockEntity(pos, state);
-    }
+	@org.jetbrains.annotations.Nullable
+	@Override
+	public BlockEntity newBlockEntity(BlockPos pos, BlockState state)
+	{
+		return new DebugItemBlockEntity(pos, state);
+	}
 
-    @Nullable
-    @Override
-    public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level pLevel, BlockState pState, BlockEntityType<T> pBlockEntityType) {
-        return BaseEntityBlock.createTickerHelper(pBlockEntityType, EnderRiftMod.RIFT_BLOCK_ENTITY.get(), RiftBlockEntity::tickStatic);
-    }
+	@Nullable
+	@Override
+	public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level pLevel, BlockState pState, BlockEntityType<T> pBlockEntityType)
+	{
+		return BaseEntityBlock.createTickerHelper(pBlockEntityType, EnderRiftMod.RIFT_BLOCK_ENTITY.get(), RiftBlockEntity::tickStatic);
+	}
 
-    @Deprecated
-    @Override
-    public List<ItemStack> getDrops(BlockState state, LootContext.Builder builder) {
-        return Lists.newArrayList(new ItemStack(this));
-    }
+	@Deprecated
+	@Override
+	public List<ItemStack> getDrops(BlockState state, LootContext.Builder builder)
+	{
+		return Lists.newArrayList(new ItemStack(this));
+	}
 
 }

--- a/src/main/java/dev/gigaherz/enderrift/debug/DebugItemBlock.java
+++ b/src/main/java/dev/gigaherz/enderrift/debug/DebugItemBlock.java
@@ -20,30 +20,30 @@ import org.jetbrains.annotations.Nullable;
 public class DebugItemBlock extends BaseEntityBlock
 {
 
-	public DebugItemBlock(Properties properties)
-	{
-		super(properties);
-	}
+    public DebugItemBlock(Properties properties)
+    {
+        super(properties);
+    }
 
-	@org.jetbrains.annotations.Nullable
-	@Override
-	public BlockEntity newBlockEntity(BlockPos pos, BlockState state)
-	{
-		return new DebugItemBlockEntity(pos, state);
-	}
+    @org.jetbrains.annotations.Nullable
+    @Override
+    public BlockEntity newBlockEntity(BlockPos pos, BlockState state)
+    {
+        return new DebugItemBlockEntity(pos, state);
+    }
 
-	@Nullable
-	@Override
-	public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level pLevel, BlockState pState, BlockEntityType<T> pBlockEntityType)
-	{
-		return BaseEntityBlock.createTickerHelper(pBlockEntityType, EnderRiftMod.RIFT_BLOCK_ENTITY.get(), RiftBlockEntity::tickStatic);
-	}
+    @Nullable
+    @Override
+    public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level pLevel, BlockState pState, BlockEntityType<T> pBlockEntityType)
+    {
+        return BaseEntityBlock.createTickerHelper(pBlockEntityType, EnderRiftMod.RIFT_BLOCK_ENTITY.get(), RiftBlockEntity::tickStatic);
+    }
 
-	@Deprecated
-	@Override
-	public List<ItemStack> getDrops(BlockState state, LootContext.Builder builder)
-	{
-		return Lists.newArrayList(new ItemStack(this));
-	}
+    @Deprecated
+    @Override
+    public List<ItemStack> getDrops(BlockState state, LootContext.Builder builder)
+    {
+        return Lists.newArrayList(new ItemStack(this));
+    }
 
 }

--- a/src/main/java/dev/gigaherz/enderrift/debug/DebugItemBlockEntity.java
+++ b/src/main/java/dev/gigaherz/enderrift/debug/DebugItemBlockEntity.java
@@ -31,15 +31,6 @@ public class DebugItemBlockEntity extends BlockEntity {
         return handler;
     }
 
-    public ItemStack getItem() {
-        ItemStack stack = new ItemStack(EnderRiftMod.DEBUG_ITEM_BLOCK_ITEM.get());
-        CompoundTag tag = new CompoundTag();
-        tag.putLong("Seed", handler.getSeed());
-        tag.putLong("Itr", handler.getIterations());
-        stack.setTag(tag);
-        return stack;
-    }
-
     @Override
     public void load(CompoundTag compound) {
         super.load(compound);
@@ -48,8 +39,10 @@ public class DebugItemBlockEntity extends BlockEntity {
     }
 
     @Override
-    protected void saveAdditional(CompoundTag compound) {
-        super.saveAdditional(compound);
+    protected void saveAdditional(CompoundTag tag) {
+        super.saveAdditional(tag);
+        tag.putLong("Seed", handler.getSeed());
+        tag.putLong("Itr", handler.getIterations());
     }
 
     @Override

--- a/src/main/java/dev/gigaherz/enderrift/debug/DebugItemBlockEntity.java
+++ b/src/main/java/dev/gigaherz/enderrift/debug/DebugItemBlockEntity.java
@@ -16,65 +16,75 @@ import net.minecraftforge.items.IItemHandler;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public class DebugItemBlockEntity extends BlockEntity {
+public class DebugItemBlockEntity extends BlockEntity
+{
 
-    private final DebugItemHandler handler = new DebugItemHandler(this);
-    private final LazyOptional<DebugItemHandler> poweredInventoryProvider = LazyOptional.of(() -> handler);
+	private final DebugItemHandler handler = new DebugItemHandler(this);
+	private final LazyOptional<DebugItemHandler> poweredInventoryProvider = LazyOptional.of(() -> handler);
 
-    public DebugItemBlockEntity(BlockPos pos, BlockState state) {
-        super(EnderRiftMod.DEBUG_ITEM_BLOCK_ENTITY.get(), pos, state);
-    }
+	public DebugItemBlockEntity(BlockPos pos, BlockState state)
+	{
+		super(EnderRiftMod.DEBUG_ITEM_BLOCK_ENTITY.get(), pos, state);
+	}
 
-    @Nullable
-    public IItemHandler getInventory() {
-        return handler;
-    }
+	@Nullable
+	public IItemHandler getInventory()
+	{
+		return handler;
+	}
 
-    @Override
-    public void load(CompoundTag compound) {
-        super.load(compound);
-        handler.setSeed(compound.getLong("Seed"));
-        handler.setIterations(compound.getLong("Itr"));
-    }
+	@Override
+	public void load(CompoundTag compound)
+	{
+		super.load(compound);
+		handler.setSeed(compound.getLong("Seed"));
+		handler.setIterations(compound.getLong("Itr"));
+	}
 
-    @Override
-    protected void saveAdditional(CompoundTag tag) {
-        super.saveAdditional(tag);
-        tag.putLong("Seed", handler.getSeed());
-        tag.putLong("Itr", handler.getIterations());
-    }
+	@Override
+	protected void saveAdditional(CompoundTag tag)
+	{
+		super.saveAdditional(tag);
+		tag.putLong("Seed", handler.getSeed());
+		tag.putLong("Itr", handler.getIterations());
+	}
 
-    @Override
-    public CompoundTag getUpdateTag() {
-        CompoundTag tag = super.getUpdateTag();
-        tag.putLong("Seed", handler.getSeed());
-        tag.putLong("Itr", handler.getIterations());
-        return tag;
-    }
+	@Override
+	public CompoundTag getUpdateTag()
+	{
+		CompoundTag tag = super.getUpdateTag();
+		tag.putLong("Seed", handler.getSeed());
+		tag.putLong("Itr", handler.getIterations());
+		return tag;
+	}
 
-    @Override
-    public void handleUpdateTag(CompoundTag tag) {
-        handler.setSeed(tag.getLong("Seed"));
-        handler.setIterations(tag.getLong("Itr"));
-    }
+	@Override
+	public void handleUpdateTag(CompoundTag tag)
+	{
+		handler.setSeed(tag.getLong("Seed"));
+		handler.setIterations(tag.getLong("Itr"));
+	}
 
-    @Nullable
-    @Override
-    public ClientboundBlockEntityDataPacket getUpdatePacket() {
-        return ClientboundBlockEntityDataPacket.create(this);
-    }
+	@Nullable
+	@Override
+	public ClientboundBlockEntityDataPacket getUpdatePacket()
+	{
+		return ClientboundBlockEntityDataPacket.create(this);
+	}
 
-    @Override
-    public void onDataPacket(Connection net, ClientboundBlockEntityDataPacket pkt) {
-        handleUpdateTag(pkt.getTag());
-    }
+	@Override
+	public void onDataPacket(Connection net, ClientboundBlockEntityDataPacket pkt)
+	{
+		handleUpdateTag(pkt.getTag());
+	}
 
-    @Nonnull
-    @Override
-    public <T> LazyOptional<T> getCapability(@Nonnull final Capability<T> cap, final @Nullable Direction side) {
-        if (cap == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
-            return poweredInventoryProvider.cast();
-        return super.getCapability(cap, side);
-    }
+	@Nonnull
+	@Override
+	public <T> LazyOptional<T> getCapability(@Nonnull final Capability<T> cap, final @Nullable Direction side)
+	{
+		if (cap == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
+			return poweredInventoryProvider.cast();
+		return super.getCapability(cap, side);
+	}
 
 }

--- a/src/main/java/dev/gigaherz/enderrift/debug/DebugItemBlockEntity.java
+++ b/src/main/java/dev/gigaherz/enderrift/debug/DebugItemBlockEntity.java
@@ -19,72 +19,72 @@ import javax.annotation.Nullable;
 public class DebugItemBlockEntity extends BlockEntity
 {
 
-	private final DebugItemHandler handler = new DebugItemHandler(this);
-	private final LazyOptional<DebugItemHandler> poweredInventoryProvider = LazyOptional.of(() -> handler);
+    private final DebugItemHandler handler = new DebugItemHandler(this);
+    private final LazyOptional<DebugItemHandler> poweredInventoryProvider = LazyOptional.of(() -> handler);
 
-	public DebugItemBlockEntity(BlockPos pos, BlockState state)
-	{
-		super(EnderRiftMod.DEBUG_ITEM_BLOCK_ENTITY.get(), pos, state);
-	}
+    public DebugItemBlockEntity(BlockPos pos, BlockState state)
+    {
+        super(EnderRiftMod.DEBUG_ITEM_BLOCK_ENTITY.get(), pos, state);
+    }
 
-	@Nullable
-	public IItemHandler getInventory()
-	{
-		return handler;
-	}
+    @Nullable
+    public IItemHandler getInventory()
+    {
+        return handler;
+    }
 
-	@Override
-	public void load(CompoundTag compound)
-	{
-		super.load(compound);
-		handler.setSeed(compound.getLong("Seed"));
-		handler.setIterations(compound.getLong("Itr"));
-	}
+    @Override
+    public void load(CompoundTag compound)
+    {
+        super.load(compound);
+        handler.setSeed(compound.getLong("Seed"));
+        handler.setIterations(compound.getLong("Itr"));
+    }
 
-	@Override
-	protected void saveAdditional(CompoundTag tag)
-	{
-		super.saveAdditional(tag);
-		tag.putLong("Seed", handler.getSeed());
-		tag.putLong("Itr", handler.getIterations());
-	}
+    @Override
+    protected void saveAdditional(CompoundTag tag)
+    {
+        super.saveAdditional(tag);
+        tag.putLong("Seed", handler.getSeed());
+        tag.putLong("Itr", handler.getIterations());
+    }
 
-	@Override
-	public CompoundTag getUpdateTag()
-	{
-		CompoundTag tag = super.getUpdateTag();
-		tag.putLong("Seed", handler.getSeed());
-		tag.putLong("Itr", handler.getIterations());
-		return tag;
-	}
+    @Override
+    public CompoundTag getUpdateTag()
+    {
+        CompoundTag tag = super.getUpdateTag();
+        tag.putLong("Seed", handler.getSeed());
+        tag.putLong("Itr", handler.getIterations());
+        return tag;
+    }
 
-	@Override
-	public void handleUpdateTag(CompoundTag tag)
-	{
-		handler.setSeed(tag.getLong("Seed"));
-		handler.setIterations(tag.getLong("Itr"));
-	}
+    @Override
+    public void handleUpdateTag(CompoundTag tag)
+    {
+        handler.setSeed(tag.getLong("Seed"));
+        handler.setIterations(tag.getLong("Itr"));
+    }
 
-	@Nullable
-	@Override
-	public ClientboundBlockEntityDataPacket getUpdatePacket()
-	{
-		return ClientboundBlockEntityDataPacket.create(this);
-	}
+    @Nullable
+    @Override
+    public ClientboundBlockEntityDataPacket getUpdatePacket()
+    {
+        return ClientboundBlockEntityDataPacket.create(this);
+    }
 
-	@Override
-	public void onDataPacket(Connection net, ClientboundBlockEntityDataPacket pkt)
-	{
-		handleUpdateTag(pkt.getTag());
-	}
+    @Override
+    public void onDataPacket(Connection net, ClientboundBlockEntityDataPacket pkt)
+    {
+        handleUpdateTag(pkt.getTag());
+    }
 
-	@Nonnull
-	@Override
-	public <T> LazyOptional<T> getCapability(@Nonnull final Capability<T> cap, final @Nullable Direction side)
-	{
-		if (cap == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
-			return poweredInventoryProvider.cast();
-		return super.getCapability(cap, side);
-	}
+    @Nonnull
+    @Override
+    public <T> LazyOptional<T> getCapability(@Nonnull final Capability<T> cap, final @Nullable Direction side)
+    {
+        if (cap == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
+            return poweredInventoryProvider.cast();
+        return super.getCapability(cap, side);
+    }
 
 }

--- a/src/main/java/dev/gigaherz/enderrift/debug/DebugItemBlockEntity.java
+++ b/src/main/java/dev/gigaherz/enderrift/debug/DebugItemBlockEntity.java
@@ -2,7 +2,6 @@ package dev.gigaherz.enderrift.debug;
 
 import dev.gigaherz.enderrift.EnderRiftMod;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;

--- a/src/main/java/dev/gigaherz/enderrift/debug/DebugItemBlockEntity.java
+++ b/src/main/java/dev/gigaherz/enderrift/debug/DebugItemBlockEntity.java
@@ -1,10 +1,12 @@
 package dev.gigaherz.enderrift.debug;
 
 import dev.gigaherz.enderrift.EnderRiftMod;
+import dev.gigaherz.enderrift.automation.driver.DriverBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.core.Direction;
 import net.minecraft.core.BlockPos;
@@ -19,8 +21,8 @@ import javax.annotation.Nullable;
 public class DebugItemBlockEntity extends BlockEntity
 {
 
-    private final DebugItemHandler handler = new DebugItemHandler(this);
-    private final LazyOptional<DebugItemHandler> poweredInventoryProvider = LazyOptional.of(() -> handler);
+    private final DebugItemHandler randomItemHandler = new DebugItemHandler(this);
+    private final LazyOptional<DebugItemHandler> randomItemHandlerProvider = LazyOptional.of(() -> randomItemHandler);
 
     public DebugItemBlockEntity(BlockPos pos, BlockState state)
     {
@@ -30,39 +32,39 @@ public class DebugItemBlockEntity extends BlockEntity
     @Nullable
     public IItemHandler getInventory()
     {
-        return handler;
+        return randomItemHandler;
     }
 
     @Override
     public void load(CompoundTag compound)
     {
         super.load(compound);
-        handler.setSeed(compound.getLong("Seed"));
-        handler.setIterations(compound.getLong("Itr"));
+        randomItemHandler.setSeed(compound.getLong("Seed"));
+        randomItemHandler.setIterations(compound.getLong("Itr"));
     }
 
     @Override
     protected void saveAdditional(CompoundTag tag)
     {
         super.saveAdditional(tag);
-        tag.putLong("Seed", handler.getSeed());
-        tag.putLong("Itr", handler.getIterations());
+        tag.putLong("Seed", randomItemHandler.getSeed());
+        tag.putLong("Itr", randomItemHandler.getIterations());
     }
 
     @Override
     public CompoundTag getUpdateTag()
     {
         CompoundTag tag = super.getUpdateTag();
-        tag.putLong("Seed", handler.getSeed());
-        tag.putLong("Itr", handler.getIterations());
+        tag.putLong("Seed", randomItemHandler.getSeed());
+        tag.putLong("Itr", randomItemHandler.getIterations());
         return tag;
     }
 
     @Override
     public void handleUpdateTag(CompoundTag tag)
     {
-        handler.setSeed(tag.getLong("Seed"));
-        handler.setIterations(tag.getLong("Itr"));
+        randomItemHandler.setSeed(tag.getLong("Seed"));
+        randomItemHandler.setIterations(tag.getLong("Itr"));
     }
 
     @Nullable
@@ -83,7 +85,7 @@ public class DebugItemBlockEntity extends BlockEntity
     public <T> LazyOptional<T> getCapability(@Nonnull final Capability<T> cap, final @Nullable Direction side)
     {
         if (cap == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
-            return poweredInventoryProvider.cast();
+            return randomItemHandlerProvider.cast();
         return super.getCapability(cap, side);
     }
 

--- a/src/main/java/dev/gigaherz/enderrift/debug/DebugItemBlockEntity.java
+++ b/src/main/java/dev/gigaherz/enderrift/debug/DebugItemBlockEntity.java
@@ -1,0 +1,88 @@
+package dev.gigaherz.enderrift.debug;
+
+import dev.gigaherz.enderrift.EnderRiftMod;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.Connection;
+import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.core.Direction;
+import net.minecraft.core.BlockPos;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.items.CapabilityItemHandler;
+import net.minecraftforge.items.IItemHandler;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class DebugItemBlockEntity extends BlockEntity {
+
+    private final DebugItemHandler handler = new DebugItemHandler(this);
+    private final LazyOptional<DebugItemHandler> poweredInventoryProvider = LazyOptional.of(() -> handler);
+
+    public DebugItemBlockEntity(BlockPos pos, BlockState state) {
+        super(EnderRiftMod.DEBUG_ITEM_BLOCK_ENTITY.get(), pos, state);
+    }
+
+    @Nullable
+    public IItemHandler getInventory() {
+        return handler;
+    }
+
+    public ItemStack getItem() {
+        ItemStack stack = new ItemStack(EnderRiftMod.DEBUG_ITEM_BLOCK_ITEM.get());
+        CompoundTag tag = new CompoundTag();
+        tag.putLong("Seed", handler.getSeed());
+        tag.putLong("Itr", handler.getIterations());
+        stack.setTag(tag);
+        return stack;
+    }
+
+    @Override
+    public void load(CompoundTag compound) {
+        super.load(compound);
+        handler.setSeed(compound.getLong("Seed"));
+        handler.setIterations(compound.getLong("Itr"));
+    }
+
+    @Override
+    protected void saveAdditional(CompoundTag compound) {
+        super.saveAdditional(compound);
+    }
+
+    @Override
+    public CompoundTag getUpdateTag() {
+        CompoundTag tag = super.getUpdateTag();
+        tag.putLong("Seed", handler.getSeed());
+        tag.putLong("Itr", handler.getIterations());
+        return tag;
+    }
+
+    @Override
+    public void handleUpdateTag(CompoundTag tag) {
+        handler.setSeed(tag.getLong("Seed"));
+        handler.setIterations(tag.getLong("Itr"));
+    }
+
+    @Nullable
+    @Override
+    public ClientboundBlockEntityDataPacket getUpdatePacket() {
+        return ClientboundBlockEntityDataPacket.create(this);
+    }
+
+    @Override
+    public void onDataPacket(Connection net, ClientboundBlockEntityDataPacket pkt) {
+        handleUpdateTag(pkt.getTag());
+    }
+
+    @Nonnull
+    @Override
+    public <T> LazyOptional<T> getCapability(@Nonnull final Capability<T> cap, final @Nullable Direction side) {
+        if (cap == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
+            return poweredInventoryProvider.cast();
+        return super.getCapability(cap, side);
+    }
+
+}

--- a/src/main/java/dev/gigaherz/enderrift/debug/DebugItemHandler.java
+++ b/src/main/java/dev/gigaherz/enderrift/debug/DebugItemHandler.java
@@ -86,15 +86,20 @@ public class DebugItemHandler implements IItemHandler
 
     private int nextInt(int max)
     {
+        if (iterations < 0 || iterations == Long.MAX_VALUE)
+        {
+            iterations = 0;
+        }
+        return nextInt(iterations++, max);
+    }
+
+    private int nextInt(long iterations, int max)
+    {
         if (max <= 0)
         {
             return 0;
         }
-        if (iterations == Long.MAX_VALUE)
-        {
-            iterations = 0;
-        }
-        long num = (iterations++) * 3432918353L;
+        long num = iterations * 3432918353L;
         num = (num << 15 | num >> 17);
         num *= 461845907L;
         long num2 = seed ^ num;

--- a/src/main/java/dev/gigaherz/enderrift/debug/DebugItemHandler.java
+++ b/src/main/java/dev/gigaherz/enderrift/debug/DebugItemHandler.java
@@ -1,0 +1,117 @@
+package dev.gigaherz.enderrift.debug;
+
+import org.jetbrains.annotations.NotNull;
+
+import net.minecraft.core.Holder;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.items.IItemHandler;
+
+public class DebugItemHandler implements IItemHandler {
+
+    private long seed;
+    private long iterations = 0L;
+
+    private final DebugItemBlockEntity entity;
+
+    public DebugItemHandler(final DebugItemBlockEntity entity) {
+        this.entity = entity;
+        this.seed = System.currentTimeMillis();
+    }
+
+    public long getSeed() {
+        return seed;
+    }
+
+    public void setSeed(long seed) {
+        this.seed = seed;
+    }
+
+    public long getIterations() {
+        return iterations;
+    }
+
+    public void setIterations(long iterations) {
+        this.iterations = iterations;
+    }
+
+    @Override
+    public int getSlots() {
+        return 1;
+    }
+
+    @Override
+    public @NotNull ItemStack getStackInSlot(int slot) {
+        long prev = iterations;
+        ItemStack stack = next();
+        iterations = prev;
+        return stack;
+    }
+
+    @Override
+    public @NotNull ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
+        return ItemStack.EMPTY;
+    }
+
+    @Override
+    public @NotNull ItemStack extractItem(int slot, int amount, boolean simulate) {
+        if (simulate) {
+            return getStackInSlot(slot);
+        }
+        return next();
+    }
+
+    @Override
+    public int getSlotLimit(int slot) {
+        return getStackInSlot(slot).getMaxStackSize();
+    }
+
+    @Override
+    public boolean isItemValid(int slot, @NotNull ItemStack stack) {
+        return false;
+    }
+
+    private int nextInt(int max) {
+        if (max <= 0) {
+            return 0;
+        }
+        if (iterations == Long.MAX_VALUE) {
+            iterations = 0;
+        }
+        long num = (iterations++) * 3432918353L;
+        num = (num << 15 | num >> 17);
+        num *= 461845907L;
+        long num2 = seed ^ num;
+        num2 = (num2 << 13 | num2 >> 19);
+        num2 = num2 * 5L + 3864292196L;
+        num2 ^= 2834544218L;
+        num2 ^= num2 >> 16;
+        num2 *= 2246822507L;
+        num2 ^= num2 >> 13;
+        num2 *= 3266489909L;
+        int number = (int) (num2 ^ num2 >> 16);
+        if (!entity.isRemoved()) {
+            entity.setChanged();
+        }
+        return Math.abs(number % max);
+    }
+
+    private ItemStack next() {
+        return next(false);
+    }
+
+    private ItemStack next(boolean nulled) {
+        Holder<Item> holder = DebugKeyCache.getItem(nextInt(DebugKeyCache.size()));
+        if (holder == null) {
+            iterations--;
+            DebugKeyCache.update();
+            if (nulled) {
+                return ItemStack.EMPTY;
+            }
+            return next(true);
+        }
+        ItemStack stack = new ItemStack(holder);
+        stack.setCount(1 + nextInt(stack.getMaxStackSize() - 1));
+        return stack;
+    }
+}

--- a/src/main/java/dev/gigaherz/enderrift/debug/DebugItemHandler.java
+++ b/src/main/java/dev/gigaherz/enderrift/debug/DebugItemHandler.java
@@ -10,128 +10,128 @@ import net.minecraftforge.items.IItemHandler;
 public class DebugItemHandler implements IItemHandler
 {
 
-	private long seed;
-	private long iterations = 0L;
+    private long seed;
+    private long iterations = 0L;
 
-	private final DebugItemBlockEntity entity;
+    private final DebugItemBlockEntity entity;
 
-	public DebugItemHandler(final DebugItemBlockEntity entity)
-	{
-		this.entity = entity;
-		this.seed = System.currentTimeMillis();
-	}
+    public DebugItemHandler(final DebugItemBlockEntity entity)
+    {
+        this.entity = entity;
+        this.seed = System.currentTimeMillis();
+    }
 
-	public long getSeed()
-	{
-		return seed;
-	}
+    public long getSeed()
+    {
+        return seed;
+    }
 
-	public void setSeed(long seed)
-	{
-		this.seed = seed;
-	}
+    public void setSeed(long seed)
+    {
+        this.seed = seed;
+    }
 
-	public long getIterations()
-	{
-		return iterations;
-	}
+    public long getIterations()
+    {
+        return iterations;
+    }
 
-	public void setIterations(long iterations)
-	{
-		this.iterations = iterations;
-	}
+    public void setIterations(long iterations)
+    {
+        this.iterations = iterations;
+    }
 
-	@Override
-	public int getSlots()
-	{
-		return 1;
-	}
+    @Override
+    public int getSlots()
+    {
+        return 1;
+    }
 
-	@Override
-	public @NotNull ItemStack getStackInSlot(int slot)
-	{
-		long prev = iterations;
-		ItemStack stack = next();
-		iterations = prev;
-		return stack;
-	}
+    @Override
+    public @NotNull ItemStack getStackInSlot(int slot)
+    {
+        long prev = iterations;
+        ItemStack stack = next();
+        iterations = prev;
+        return stack;
+    }
 
-	@Override
-	public @NotNull ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate)
-	{
-		return ItemStack.EMPTY;
-	}
+    @Override
+    public @NotNull ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate)
+    {
+        return ItemStack.EMPTY;
+    }
 
-	@Override
-	public @NotNull ItemStack extractItem(int slot, int amount, boolean simulate)
-	{
-		if (simulate)
-		{
-			return getStackInSlot(slot);
-		}
-		return next();
-	}
+    @Override
+    public @NotNull ItemStack extractItem(int slot, int amount, boolean simulate)
+    {
+        if (simulate)
+        {
+            return getStackInSlot(slot);
+        }
+        return next();
+    }
 
-	@Override
-	public int getSlotLimit(int slot)
-	{
-		return getStackInSlot(slot).getMaxStackSize();
-	}
+    @Override
+    public int getSlotLimit(int slot)
+    {
+        return getStackInSlot(slot).getMaxStackSize();
+    }
 
-	@Override
-	public boolean isItemValid(int slot, @NotNull ItemStack stack)
-	{
-		return false;
-	}
+    @Override
+    public boolean isItemValid(int slot, @NotNull ItemStack stack)
+    {
+        return false;
+    }
 
-	private int nextInt(int max)
-	{
-		if (max <= 0)
-		{
-			return 0;
-		}
-		if (iterations == Long.MAX_VALUE)
-		{
-			iterations = 0;
-		}
-		long num = (iterations++) * 3432918353L;
-		num = (num << 15 | num >> 17);
-		num *= 461845907L;
-		long num2 = seed ^ num;
-		num2 = (num2 << 13 | num2 >> 19);
-		num2 = num2 * 5L + 3864292196L;
-		num2 ^= 2834544218L;
-		num2 ^= num2 >> 16;
-		num2 *= 2246822507L;
-		num2 ^= num2 >> 13;
-		num2 *= 3266489909L;
-		int number = (int) (num2 ^ num2 >> 16);
-		if (!entity.isRemoved())
-		{
-			entity.setChanged();
-		}
-		return Math.abs(number % max);
-	}
+    private int nextInt(int max)
+    {
+        if (max <= 0)
+        {
+            return 0;
+        }
+        if (iterations == Long.MAX_VALUE)
+        {
+            iterations = 0;
+        }
+        long num = (iterations++) * 3432918353L;
+        num = (num << 15 | num >> 17);
+        num *= 461845907L;
+        long num2 = seed ^ num;
+        num2 = (num2 << 13 | num2 >> 19);
+        num2 = num2 * 5L + 3864292196L;
+        num2 ^= 2834544218L;
+        num2 ^= num2 >> 16;
+        num2 *= 2246822507L;
+        num2 ^= num2 >> 13;
+        num2 *= 3266489909L;
+        int number = (int) (num2 ^ num2 >> 16);
+        if (!entity.isRemoved())
+        {
+            entity.setChanged();
+        }
+        return Math.abs(number % max);
+    }
 
-	private ItemStack next()
-	{
-		return next(false);
-	}
+    private ItemStack next()
+    {
+        return next(false);
+    }
 
-	private ItemStack next(boolean nulled)
-	{
-		Holder<Item> holder = DebugKeyCache.getItem(nextInt(DebugKeyCache.size()));
-		if (holder == null)
-		{
-			DebugKeyCache.update();
-			if (nulled)
-			{
-				return ItemStack.EMPTY;
-			}
-			return next(true);
-		}
-		ItemStack stack = new ItemStack(holder);
-		stack.setCount(1 + nextInt(stack.getMaxStackSize() - 1));
-		return stack;
-	}
+    private ItemStack next(boolean nulled)
+    {
+        Holder<Item> holder = DebugKeyCache.getItem(nextInt(DebugKeyCache.size()));
+        if (holder == null)
+        {
+            DebugKeyCache.update();
+            if (nulled)
+            {
+                return ItemStack.EMPTY;
+            }
+            return next(true);
+        }
+        ItemStack stack = new ItemStack(holder);
+        stack.setCount(1 + nextInt(stack.getMaxStackSize() - 1));
+        return stack;
+    }
 }

--- a/src/main/java/dev/gigaherz/enderrift/debug/DebugItemHandler.java
+++ b/src/main/java/dev/gigaherz/enderrift/debug/DebugItemHandler.java
@@ -7,110 +7,131 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.items.IItemHandler;
 
-public class DebugItemHandler implements IItemHandler {
+public class DebugItemHandler implements IItemHandler
+{
 
-    private long seed;
-    private long iterations = 0L;
+	private long seed;
+	private long iterations = 0L;
 
-    private final DebugItemBlockEntity entity;
+	private final DebugItemBlockEntity entity;
 
-    public DebugItemHandler(final DebugItemBlockEntity entity) {
-        this.entity = entity;
-        this.seed = System.currentTimeMillis();
-    }
+	public DebugItemHandler(final DebugItemBlockEntity entity)
+	{
+		this.entity = entity;
+		this.seed = System.currentTimeMillis();
+	}
 
-    public long getSeed() {
-        return seed;
-    }
+	public long getSeed()
+	{
+		return seed;
+	}
 
-    public void setSeed(long seed) {
-        this.seed = seed;
-    }
+	public void setSeed(long seed)
+	{
+		this.seed = seed;
+	}
 
-    public long getIterations() {
-        return iterations;
-    }
+	public long getIterations()
+	{
+		return iterations;
+	}
 
-    public void setIterations(long iterations) {
-        this.iterations = iterations;
-    }
+	public void setIterations(long iterations)
+	{
+		this.iterations = iterations;
+	}
 
-    @Override
-    public int getSlots() {
-        return 1;
-    }
+	@Override
+	public int getSlots()
+	{
+		return 1;
+	}
 
-    @Override
-    public @NotNull ItemStack getStackInSlot(int slot) {
-        long prev = iterations;
-        ItemStack stack = next();
-        iterations = prev;
-        return stack;
-    }
+	@Override
+	public @NotNull ItemStack getStackInSlot(int slot)
+	{
+		long prev = iterations;
+		ItemStack stack = next();
+		iterations = prev;
+		return stack;
+	}
 
-    @Override
-    public @NotNull ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
-        return ItemStack.EMPTY;
-    }
+	@Override
+	public @NotNull ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate)
+	{
+		return ItemStack.EMPTY;
+	}
 
-    @Override
-    public @NotNull ItemStack extractItem(int slot, int amount, boolean simulate) {
-        if (simulate) {
-            return getStackInSlot(slot);
-        }
-        return next();
-    }
+	@Override
+	public @NotNull ItemStack extractItem(int slot, int amount, boolean simulate)
+	{
+		if (simulate)
+		{
+			return getStackInSlot(slot);
+		}
+		return next();
+	}
 
-    @Override
-    public int getSlotLimit(int slot) {
-        return getStackInSlot(slot).getMaxStackSize();
-    }
+	@Override
+	public int getSlotLimit(int slot)
+	{
+		return getStackInSlot(slot).getMaxStackSize();
+	}
 
-    @Override
-    public boolean isItemValid(int slot, @NotNull ItemStack stack) {
-        return false;
-    }
+	@Override
+	public boolean isItemValid(int slot, @NotNull ItemStack stack)
+	{
+		return false;
+	}
 
-    private int nextInt(int max) {
-        if (max <= 0) {
-            return 0;
-        }
-        if (iterations == Long.MAX_VALUE) {
-            iterations = 0;
-        }
-        long num = (iterations++) * 3432918353L;
-        num = (num << 15 | num >> 17);
-        num *= 461845907L;
-        long num2 = seed ^ num;
-        num2 = (num2 << 13 | num2 >> 19);
-        num2 = num2 * 5L + 3864292196L;
-        num2 ^= 2834544218L;
-        num2 ^= num2 >> 16;
-        num2 *= 2246822507L;
-        num2 ^= num2 >> 13;
-        num2 *= 3266489909L;
-        int number = (int) (num2 ^ num2 >> 16);
-        if (!entity.isRemoved()) {
-            entity.setChanged();
-        }
-        return Math.abs(number % max);
-    }
+	private int nextInt(int max)
+	{
+		if (max <= 0)
+		{
+			return 0;
+		}
+		if (iterations == Long.MAX_VALUE)
+		{
+			iterations = 0;
+		}
+		long num = (iterations++) * 3432918353L;
+		num = (num << 15 | num >> 17);
+		num *= 461845907L;
+		long num2 = seed ^ num;
+		num2 = (num2 << 13 | num2 >> 19);
+		num2 = num2 * 5L + 3864292196L;
+		num2 ^= 2834544218L;
+		num2 ^= num2 >> 16;
+		num2 *= 2246822507L;
+		num2 ^= num2 >> 13;
+		num2 *= 3266489909L;
+		int number = (int) (num2 ^ num2 >> 16);
+		if (!entity.isRemoved())
+		{
+			entity.setChanged();
+		}
+		return Math.abs(number % max);
+	}
 
-    private ItemStack next() {
-        return next(false);
-    }
+	private ItemStack next()
+	{
+		return next(false);
+	}
 
-    private ItemStack next(boolean nulled) {
-        Holder<Item> holder = DebugKeyCache.getItem(nextInt(DebugKeyCache.size()));
-        if (holder == null) {
-            DebugKeyCache.update();
-            if (nulled) {
-                return ItemStack.EMPTY;
-            }
-            return next(true);
-        }
-        ItemStack stack = new ItemStack(holder);
-        stack.setCount(1 + nextInt(stack.getMaxStackSize() - 1));
-        return stack;
-    }
+	private ItemStack next(boolean nulled)
+	{
+		Holder<Item> holder = DebugKeyCache.getItem(nextInt(DebugKeyCache.size()));
+		if (holder == null)
+		{
+			DebugKeyCache.update();
+			if (nulled)
+			{
+				return ItemStack.EMPTY;
+			}
+			return next(true);
+		}
+		ItemStack stack = new ItemStack(holder);
+		stack.setCount(1 + nextInt(stack.getMaxStackSize() - 1));
+		return stack;
+	}
 }

--- a/src/main/java/dev/gigaherz/enderrift/debug/DebugItemHandler.java
+++ b/src/main/java/dev/gigaherz/enderrift/debug/DebugItemHandler.java
@@ -103,7 +103,6 @@ public class DebugItemHandler implements IItemHandler {
     private ItemStack next(boolean nulled) {
         Holder<Item> holder = DebugKeyCache.getItem(nextInt(DebugKeyCache.size()));
         if (holder == null) {
-            iterations--;
             DebugKeyCache.update();
             if (nulled) {
                 return ItemStack.EMPTY;

--- a/src/main/java/dev/gigaherz/enderrift/debug/DebugKeyCache.java
+++ b/src/main/java/dev/gigaherz/enderrift/debug/DebugKeyCache.java
@@ -8,40 +8,40 @@ import net.minecraftforge.registries.ForgeRegistries;
 public class DebugKeyCache
 {
 
-	private DebugKeyCache()
-	{
-		throw new UnsupportedOperationException();
-	}
+    private DebugKeyCache()
+    {
+        throw new UnsupportedOperationException();
+    }
 
-	private static ResourceLocation[] items;
+    private static ResourceLocation[] items;
 
-	public static int size()
-	{
-		return items == null ? 0 : items.length;
-	}
+    public static int size()
+    {
+        return items == null ? 0 : items.length;
+    }
 
-	public static Holder<Item> getItem(int index)
-	{
-		ResourceLocation location = get(index);
-		if (location == null)
-		{
-			return null;
-		}
-		return ForgeRegistries.ITEMS.getHolder(location).orElse(null);
-	}
+    public static Holder<Item> getItem(int index)
+    {
+        ResourceLocation location = get(index);
+        if (location == null)
+        {
+            return null;
+        }
+        return ForgeRegistries.ITEMS.getHolder(location).orElse(null);
+    }
 
-	public static ResourceLocation get(int index)
-	{
-		if (index >= size() || index < 0)
-		{
-			return null;
-		}
-		return items[index];
-	}
+    public static ResourceLocation get(int index)
+    {
+        if (index >= size() || index < 0)
+        {
+            return null;
+        }
+        return items[index];
+    }
 
-	public static void update()
-	{
-		items = ForgeRegistries.ITEMS.getKeys().toArray(ResourceLocation[]::new);
-	}
+    public static void update()
+    {
+        items = ForgeRegistries.ITEMS.getKeys().toArray(ResourceLocation[]::new);
+    }
 
 }

--- a/src/main/java/dev/gigaherz/enderrift/debug/DebugKeyCache.java
+++ b/src/main/java/dev/gigaherz/enderrift/debug/DebugKeyCache.java
@@ -5,35 +5,43 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 import net.minecraftforge.registries.ForgeRegistries;
 
-public class DebugKeyCache {
+public class DebugKeyCache
+{
 
-    private DebugKeyCache() {
-        throw new UnsupportedOperationException();
-    }
+	private DebugKeyCache()
+	{
+		throw new UnsupportedOperationException();
+	}
 
-    private static ResourceLocation[] items;
+	private static ResourceLocation[] items;
 
-    public static int size() {
-        return items == null ? 0 : items.length;
-    }
+	public static int size()
+	{
+		return items == null ? 0 : items.length;
+	}
 
-    public static Holder<Item> getItem(int index) {
-        ResourceLocation location = get(index);
-        if (location == null) {
-            return null;
-        }
-        return ForgeRegistries.ITEMS.getHolder(location).orElse(null);
-    }
+	public static Holder<Item> getItem(int index)
+	{
+		ResourceLocation location = get(index);
+		if (location == null)
+		{
+			return null;
+		}
+		return ForgeRegistries.ITEMS.getHolder(location).orElse(null);
+	}
 
-    public static ResourceLocation get(int index) {
-        if (index >= size() || index < 0) {
-            return null;
-        }
-        return items[index];
-    }
+	public static ResourceLocation get(int index)
+	{
+		if (index >= size() || index < 0)
+		{
+			return null;
+		}
+		return items[index];
+	}
 
-    public static void update() {
-        items = ForgeRegistries.ITEMS.getKeys().toArray(ResourceLocation[]::new);
-    }
+	public static void update()
+	{
+		items = ForgeRegistries.ITEMS.getKeys().toArray(ResourceLocation[]::new);
+	}
 
 }

--- a/src/main/java/dev/gigaherz/enderrift/debug/DebugKeyCache.java
+++ b/src/main/java/dev/gigaherz/enderrift/debug/DebugKeyCache.java
@@ -1,0 +1,39 @@
+package dev.gigaherz.enderrift.debug;
+
+import net.minecraft.core.Holder;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
+import net.minecraftforge.registries.ForgeRegistries;
+
+public class DebugKeyCache {
+
+    private DebugKeyCache() {
+        throw new UnsupportedOperationException();
+    }
+
+    private static ResourceLocation[] items;
+
+    public static int size() {
+        return items == null ? 0 : items.length;
+    }
+
+    public static Holder<Item> getItem(int index) {
+        ResourceLocation location = get(index);
+        if (location == null) {
+            return null;
+        }
+        return ForgeRegistries.ITEMS.getHolder(location).orElse(null);
+    }
+
+    public static ResourceLocation get(int index) {
+        if (index >= size() || index < 0) {
+            return null;
+        }
+        return items[index];
+    }
+
+    public static void update() {
+        items = ForgeRegistries.ITEMS.getKeys().toArray(ResourceLocation[]::new);
+    }
+
+}

--- a/src/main/java/dev/gigaherz/enderrift/rift/IRiftChangeListener.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/IRiftChangeListener.java
@@ -10,7 +10,7 @@ public interface IRiftChangeListener
     boolean isInvalid();
 
     void onRiftChanged();
-    
+
     Optional<Level> getRiftLevel();
 
     Optional<BlockPos> getLocation();

--- a/src/main/java/dev/gigaherz/enderrift/rift/IRiftChangeListener.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/IRiftChangeListener.java
@@ -1,6 +1,7 @@
 package dev.gigaherz.enderrift.rift;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
 
 import java.util.Optional;
 
@@ -9,6 +10,8 @@ public interface IRiftChangeListener
     boolean isInvalid();
 
     void onRiftChanged();
+    
+    Optional<Level> getRiftLevel();
 
     Optional<BlockPos> getLocation();
 }

--- a/src/main/java/dev/gigaherz/enderrift/rift/RiftBlock.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/RiftBlock.java
@@ -31,8 +31,6 @@ import java.util.List;
 
 import org.jetbrains.annotations.Nullable;
 
-import net.minecraft.world.level.block.state.BlockBehaviour.Properties;
-
 public class RiftBlock extends BaseEntityBlock
 {
     public static final BooleanProperty ASSEMBLED = BooleanProperty.create("assembled");

--- a/src/main/java/dev/gigaherz/enderrift/rift/RiftBlockEntity.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/RiftBlockEntity.java
@@ -5,6 +5,7 @@ import dev.gigaherz.enderrift.common.EnergyBuffer;
 import dev.gigaherz.enderrift.rift.storage.RiftHolder;
 import dev.gigaherz.enderrift.rift.storage.RiftInventory;
 import dev.gigaherz.enderrift.rift.storage.RiftStorage;
+import dev.gigaherz.enderrift.rift.storage.migration.RiftMigration_17_08_2022;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.item.ItemStack;
@@ -154,8 +155,11 @@ public class RiftBlockEntity extends BlockEntity implements IRiftChangeListener 
 
         energyBuffer.deserializeNBT(compound.get("Energy"));
         powered = compound.getBoolean("Powered");
-        if(compound.hasUUID("RiftId")) {
-            holder = RiftStorage.get().getRift(compound.getUUID("RiftId"));
+        if (compound.contains("RiftId")) {
+            RiftStorage storage = RiftStorage.get();
+            UUID id = compound.hasUUID("RiftId") ? compound.getUUID("RiftId")
+                : storage.getMigration(RiftMigration_17_08_2022.class).getMigratedId(compound.getInt("RiftId"));
+            holder = storage.getRift(id);
         }
     }
 
@@ -165,10 +169,9 @@ public class RiftBlockEntity extends BlockEntity implements IRiftChangeListener 
 
         compound.put("Energy", energyBuffer.serializeNBT());
         compound.putBoolean("Powered", powered);
+        compound.remove("RiftId");
         if (holder != null) {
             compound.putUUID("RiftId", holder.getId());
-        } else {
-            compound.remove("RiftId");
         }
     }
 

--- a/src/main/java/dev/gigaherz/enderrift/rift/RiftBlockEntity.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/RiftBlockEntity.java
@@ -29,304 +29,351 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
 
-public class RiftBlockEntity extends BlockEntity implements IRiftChangeListener {
-    private static final int STARTUP_POWER = 10000;
-    public static final int BUFFER_POWER = 1000000;
-    private final Random rand = new Random();
+public class RiftBlockEntity extends BlockEntity implements IRiftChangeListener
+{
+	private static final int STARTUP_POWER = 10000;
+	public static final int BUFFER_POWER = 1000000;
+	private final Random rand = new Random();
 
-    private EnergyBuffer energyBuffer = new EnergyBuffer(BUFFER_POWER);
+	private EnergyBuffer energyBuffer = new EnergyBuffer(BUFFER_POWER);
 
-    private boolean powered;
-    private RiftHolder holder;
-    private boolean listenerState;
+	private boolean powered;
+	private RiftHolder holder;
+	private boolean listenerState;
 
-    // Client-side, for rendering
-    private float lastPoweringState;
-    private float poweringState;
-    private boolean poweringStartParticlesSpawned = false;
-    // End of Client-side fields
+	// Client-side, for rendering
+	private float lastPoweringState;
+	private float poweringState;
+	private boolean poweringStartParticlesSpawned = false;
+	// End of Client-side fields
 
-    public PoweredInventory poweredInventory = new PoweredInventory();
-    public LazyOptional<IItemHandler> poweredInventoryProvider = LazyOptional.of(() -> poweredInventory);
+	public PoweredInventory poweredInventory = new PoweredInventory();
+	public LazyOptional<IItemHandler> poweredInventoryProvider = LazyOptional.of(() -> poweredInventory);
 
-    public RiftBlockEntity(BlockPos pos, BlockState state) {
-        super(EnderRiftMod.RIFT_BLOCK_ENTITY.get(), pos, state);
-    }
+	public RiftBlockEntity(BlockPos pos, BlockState state)
+	{
+		super(EnderRiftMod.RIFT_BLOCK_ENTITY.get(), pos, state);
+	}
 
-    public Optional<IEnergyStorage> getEnergyBuffer() {
-        return Optional.of(energyBuffer);
-    }
+	public Optional<IEnergyStorage> getEnergyBuffer()
+	{
+		return Optional.of(energyBuffer);
+	}
 
-    public void tick() {
-        if (level.isClientSide) {
-            lastPoweringState = poweringState;
-            if (powered) {
-                if (!poweringStartParticlesSpawned) {
-                    poweringStartParticlesSpawned = true;
+	public void tick()
+	{
+		if (level.isClientSide)
+		{
+			lastPoweringState = poweringState;
+			if (powered)
+			{
+				if (!poweringStartParticlesSpawned)
+				{
+					poweringStartParticlesSpawned = true;
 
-                    for (int i = 0; i < 32; ++i) {
-                        this.level.addParticle(ParticleTypes.CRIT, this.worldPosition.getX() + 0.5, this.worldPosition.getY() + 0.5,
-                            this.worldPosition.getZ() + 0.5, this.rand.nextGaussian(), this.rand.nextGaussian(), this.rand.nextGaussian());
-                        this.level.addParticle(ParticleTypes.PORTAL, this.worldPosition.getX() + 0.5, this.worldPosition.getY() + 0.5,
-                            this.worldPosition.getZ() + 0.5, this.rand.nextGaussian(), this.rand.nextGaussian(), this.rand.nextGaussian());
-                    }
-                }
-                if (poweringState < 1)
-                    poweringState += 0.1f;
-                else
-                    poweringState = 1;
-            } else {
-                poweringStartParticlesSpawned = false;
-                if (poweringState > 0)
-                    poweringState -= 0.02f;
-                else
-                    poweringState = 0;
-            }
-            return;
-        }
+					for (int i = 0; i < 32; ++i)
+					{
+						this.level.addParticle(ParticleTypes.CRIT, this.worldPosition.getX() + 0.5, this.worldPosition.getY() + 0.5, this.worldPosition.getZ() + 0.5, this.rand.nextGaussian(), this.rand.nextGaussian(), this.rand.nextGaussian());
+						this.level.addParticle(ParticleTypes.PORTAL, this.worldPosition.getX() + 0.5, this.worldPosition.getY() + 0.5, this.worldPosition.getZ() + 0.5, this.rand.nextGaussian(), this.rand.nextGaussian(), this.rand.nextGaussian());
+					}
+				}
+				if (poweringState < 1)
+					poweringState += 0.1f;
+				else
+					poweringState = 1;
+			} else
+			{
+				poweringStartParticlesSpawned = false;
+				if (poweringState > 0)
+					poweringState -= 0.02f;
+				else
+					poweringState = 0;
+			}
+			return;
+		}
 
-        int energyUsage = getEnergyUsage();
-        int energyStored = energyBuffer.getEnergyStored();
-        if (energyStored > energyBuffer.getMaxEnergyStored()) {
-            energyStored = energyBuffer.getMaxEnergyStored();
-            energyBuffer.setEnergy(energyStored);
-        }
+		int energyUsage = getEnergyUsage();
+		int energyStored = energyBuffer.getEnergyStored();
+		if (energyStored > energyBuffer.getMaxEnergyStored())
+		{
+			energyStored = energyBuffer.getMaxEnergyStored();
+			energyBuffer.setEnergy(energyStored);
+		}
 
-        if (energyStored > energyUsage && !level.hasNeighborSignal(worldPosition)) {
-            if (powered) {
-                energyBuffer.setEnergy(energyStored - energyUsage);
-            } else if (energyStored >= STARTUP_POWER) {
-                powered = true;
-                energyBuffer.setEnergy(energyStored - STARTUP_POWER);
-                BlockState state = level.getBlockState(worldPosition);
-                level.sendBlockUpdated(worldPosition, state, state, 3);
-            }
-        } else {
-            powered = false;
-            BlockState state = level.getBlockState(worldPosition);
-            level.sendBlockUpdated(worldPosition, state, state, 3);
-        }
-    }
+		if (energyStored > energyUsage && !level.hasNeighborSignal(worldPosition))
+		{
+			if (powered)
+			{
+				energyBuffer.setEnergy(energyStored - energyUsage);
+			} else if (energyStored >= STARTUP_POWER)
+			{
+				powered = true;
+				energyBuffer.setEnergy(energyStored - STARTUP_POWER);
+				BlockState state = level.getBlockState(worldPosition);
+				level.sendBlockUpdated(worldPosition, state, state, 3);
+			}
+		} else
+		{
+			powered = false;
+			BlockState state = level.getBlockState(worldPosition);
+			level.sendBlockUpdated(worldPosition, state, state, 3);
+		}
+	}
 
-    public void assemble(RiftHolder holder) {
-        this.holder = holder;
-        listenerState = false;
-        setChanged();
-    }
+	public void assemble(RiftHolder holder)
+	{
+		this.holder = holder;
+		listenerState = false;
+		setChanged();
+	}
 
-    public void unassemble() {
-        holder = null;
-        listenerState = false;
-        setChanged();
-    }
+	public void unassemble()
+	{
+		holder = null;
+		listenerState = false;
+		setChanged();
+	}
 
-    @Nullable
-    public RiftInventory getInventory() {
-        if (holder == null)
-            return null;
+	@Nullable
+	public RiftInventory getInventory()
+	{
+		if (holder == null)
+			return null;
 
-        if (!listenerState && level != null && !level.isClientSide) {
-            holder.getInventoryOrCreate().addWeakListener(this);
-            listenerState = true;
-        }
-        return holder.getInventory();
-    }
+		if (!listenerState && level != null && !level.isClientSide)
+		{
+			holder.getInventoryOrCreate().addWeakListener(this);
+			listenerState = true;
+		}
+		return holder.getInventory();
+	}
 
-    public int countInventoryStacks() {
-        IItemHandler handler = getInventory();
-        return handler == null ? 0 : (handler.getSlots() - 1);
-    }
+	public int countInventoryStacks()
+	{
+		IItemHandler handler = getInventory();
+		return handler == null ? 0 : (handler.getSlots() - 1);
+	}
 
-    public ItemStack getRiftItem() {
-        ItemStack stack = new ItemStack(EnderRiftMod.RIFT_ORB.get());
+	public ItemStack getRiftItem()
+	{
+		ItemStack stack = new ItemStack(EnderRiftMod.RIFT_ORB.get());
 
-        CompoundTag tag = new CompoundTag();
+		CompoundTag tag = new CompoundTag();
 
-        tag.putUUID("RiftId", holder.getId());
+		tag.putUUID("RiftId", holder.getId());
 
-        stack.setTag(tag);
+		stack.setTag(tag);
 
-        return stack;
-    }
+		return stack;
+	}
 
-    @Override
-    public void load(CompoundTag compound) {
-        super.load(compound);
+	@Override
+	public void load(CompoundTag compound)
+	{
+		super.load(compound);
 
-        energyBuffer.deserializeNBT(compound.get("Energy"));
-        powered = compound.getBoolean("Powered");
-        if (compound.contains("RiftId")) {
-            RiftStorage storage = RiftStorage.get();
-            UUID id = compound.hasUUID("RiftId") ? compound.getUUID("RiftId")
-                : storage.getMigration(RiftMigration_17_08_2022.class).getMigratedId(compound.getInt("RiftId"));
-            holder = storage.getRift(id);
-        }
-    }
+		energyBuffer.deserializeNBT(compound.get("Energy"));
+		powered = compound.getBoolean("Powered");
+		if (compound.contains("RiftId"))
+		{
+			RiftStorage storage = RiftStorage.get();
+			UUID id = compound.hasUUID("RiftId") ? compound.getUUID("RiftId") : storage.getMigration(RiftMigration_17_08_2022.class).getMigratedId(compound.getInt("RiftId"));
+			holder = storage.getRift(id);
+		}
+	}
 
-    @Override
-    protected void saveAdditional(CompoundTag compound) {
-        super.saveAdditional(compound);
+	@Override
+	protected void saveAdditional(CompoundTag compound)
+	{
+		super.saveAdditional(compound);
 
-        compound.put("Energy", energyBuffer.serializeNBT());
-        compound.putBoolean("Powered", powered);
-        compound.remove("RiftId");
-        if (holder != null) {
-            compound.putUUID("RiftId", holder.getId());
-        }
-    }
+		compound.put("Energy", energyBuffer.serializeNBT());
+		compound.putBoolean("Powered", powered);
+		compound.remove("RiftId");
+		if (holder != null)
+		{
+			compound.putUUID("RiftId", holder.getId());
+		}
+	}
 
-    @Override
-    public CompoundTag getUpdateTag() {
-        CompoundTag tag = super.getUpdateTag();
-        tag.putBoolean("Powered", powered);
-        return tag;
-    }
+	@Override
+	public CompoundTag getUpdateTag()
+	{
+		CompoundTag tag = super.getUpdateTag();
+		tag.putBoolean("Powered", powered);
+		return tag;
+	}
 
-    @Override
-    public void handleUpdateTag(CompoundTag tag) {
-        powered = tag.getBoolean("Powered");
-    }
+	@Override
+	public void handleUpdateTag(CompoundTag tag)
+	{
+		powered = tag.getBoolean("Powered");
+	}
 
-    @Nullable
-    @Override
-    public ClientboundBlockEntityDataPacket getUpdatePacket() {
-        return ClientboundBlockEntityDataPacket.create(this);
-    }
+	@Nullable
+	@Override
+	public ClientboundBlockEntityDataPacket getUpdatePacket()
+	{
+		return ClientboundBlockEntityDataPacket.create(this);
+	}
 
-    @Override
-    public void onDataPacket(Connection net, ClientboundBlockEntityDataPacket pkt) {
-        handleUpdateTag(pkt.getTag());
-    }
+	@Override
+	public void onDataPacket(Connection net, ClientboundBlockEntityDataPacket pkt)
+	{
+		handleUpdateTag(pkt.getTag());
+	}
 
-    @Nonnull
-    @Override
-    public <T> LazyOptional<T> getCapability(@Nonnull final Capability<T> cap, final @Nullable Direction side) {
-        if (cap == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
-            return poweredInventoryProvider.cast();
-        return super.getCapability(cap, side);
-    }
+	@Nonnull
+	@Override
+	public <T> LazyOptional<T> getCapability(@Nonnull final Capability<T> cap, final @Nullable Direction side)
+	{
+		if (cap == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
+			return poweredInventoryProvider.cast();
+		return super.getCapability(cap, side);
+	}
 
-    public ItemStack chooseRandomStack() {
-        IItemHandler handler = getInventory();
-        if (handler == null)
-            return ItemStack.EMPTY;
+	public ItemStack chooseRandomStack()
+	{
+		IItemHandler handler = getInventory();
+		if (handler == null)
+			return ItemStack.EMPTY;
 
-        int max = handler.getSlots();
+		int max = handler.getSlots();
 
-        if (max <= 0)
-            return ItemStack.EMPTY;
+		if (max <= 0)
+			return ItemStack.EMPTY;
 
-        int slot = rand.nextInt(max);
+		int slot = rand.nextInt(max);
 
-        return poweredInventory.getStackInSlot(slot);
-    }
+		return poweredInventory.getStackInSlot(slot);
+	}
 
-    public UUID getRiftId() {
-        if (holder == null) {
-            return null;
-        }
-        return holder.getId();
-    }
+	public UUID getRiftId()
+	{
+		if (holder == null)
+		{
+			return null;
+		}
+		return holder.getId();
+	}
 
-    public int getEnergyUsage() {
-        IItemHandler handler = getInventory();
-        if (handler == null)
-            return 0;
-        return Mth.ceil(Math.pow(handler.getSlots(), 0.8));
-    }
+	public int getEnergyUsage()
+	{
+		IItemHandler handler = getInventory();
+		if (handler == null)
+			return 0;
+		return Mth.ceil(Math.pow(handler.getSlots(), 0.8));
+	}
 
-    public boolean isPowered() {
-        return powered;
-    }
+	public boolean isPowered()
+	{
+		return powered;
+	}
 
-    public float getPoweringState() {
-        return poweringState;
-    }
+	public float getPoweringState()
+	{
+		return poweringState;
+	}
 
-    public float getLastPoweringState() {
-        return lastPoweringState;
-    }
+	public float getLastPoweringState()
+	{
+		return lastPoweringState;
+	}
 
-    @Override
-    public boolean isInvalid() {
-        return isRemoved();
-    }
+	@Override
+	public boolean isInvalid()
+	{
+		return isRemoved();
+	}
 
-    @Override
-    public void onRiftChanged() {
-        setChanged();
-    }
+	@Override
+	public void onRiftChanged()
+	{
+		setChanged();
+	}
 
-    @Override
-    public Optional<Level> getRiftLevel() {
-        return Optional.ofNullable(getLevel());
-    }
+	@Override
+	public Optional<Level> getRiftLevel()
+	{
+		return Optional.ofNullable(getLevel());
+	}
 
-    @Override
-    public Optional<BlockPos> getLocation() {
-        return Optional.ofNullable(getBlockPos());
-    }
+	@Override
+	public Optional<BlockPos> getLocation()
+	{
+		return Optional.ofNullable(getBlockPos());
+	}
 
-    public static void tickStatic(Level level, BlockPos blockPos, BlockState blockState, RiftBlockEntity te) {
-        te.tick();
-    }
+	public static void tickStatic(Level level, BlockPos blockPos, BlockState blockState, RiftBlockEntity te)
+	{
+		te.tick();
+	}
 
-    public class PoweredInventory implements IItemHandler {
-        public long getCount(int slot) {
-            RiftInventory inventory = getInventory();
-            if (inventory == null) {
-                return 0;
-            }
-            return inventory.getCount(slot);
-        }
+	public class PoweredInventory implements IItemHandler
+	{
+		public long getCount(int slot)
+		{
+			RiftInventory inventory = getInventory();
+			if (inventory == null)
+			{
+				return 0;
+			}
+			return inventory.getCount(slot);
+		}
 
-        @Override
-        public int getSlots() {
-            IItemHandler handler = getInventory();
-            if (handler == null)
-                return 0;
+		@Override
+		public int getSlots()
+		{
+			IItemHandler handler = getInventory();
+			if (handler == null)
+				return 0;
 
-            return handler.getSlots();
-        }
+			return handler.getSlots();
+		}
 
-        @Override
-        public ItemStack getStackInSlot(int slot) {
-            if (!powered)
-                return ItemStack.EMPTY;
-            IItemHandler handler = getInventory();
-            if (handler == null)
-                return ItemStack.EMPTY;
-            return handler.getStackInSlot(slot);
-        }
+		@Override
+		public ItemStack getStackInSlot(int slot)
+		{
+			if (!powered)
+				return ItemStack.EMPTY;
+			IItemHandler handler = getInventory();
+			if (handler == null)
+				return ItemStack.EMPTY;
+			return handler.getStackInSlot(slot);
+		}
 
-        @Override
-        public ItemStack insertItem(int slot, ItemStack stack, boolean simulate) {
-            if (!powered)
-                return stack;
-            IItemHandler handler = getInventory();
-            if (handler == null)
-                return stack;
-            return handler.insertItem(slot, stack, simulate);
-        }
+		@Override
+		public ItemStack insertItem(int slot, ItemStack stack, boolean simulate)
+		{
+			if (!powered)
+				return stack;
+			IItemHandler handler = getInventory();
+			if (handler == null)
+				return stack;
+			return handler.insertItem(slot, stack, simulate);
+		}
 
-        @Override
-        public ItemStack extractItem(int slot, int amount, boolean simulate) {
-            if (!powered)
-                return ItemStack.EMPTY;
-            IItemHandler handler = getInventory();
-            if (handler == null)
-                return ItemStack.EMPTY;
-            return handler.extractItem(slot, amount, simulate);
-        }
+		@Override
+		public ItemStack extractItem(int slot, int amount, boolean simulate)
+		{
+			if (!powered)
+				return ItemStack.EMPTY;
+			IItemHandler handler = getInventory();
+			if (handler == null)
+				return ItemStack.EMPTY;
+			return handler.extractItem(slot, amount, simulate);
+		}
 
-        @Override
-        public int getSlotLimit(int slot) {
-            return 64;
-        }
+		@Override
+		public int getSlotLimit(int slot)
+		{
+			return 64;
+		}
 
-        @Override
-        public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
-            return true;
-        }
-    }
+		@Override
+		public boolean isItemValid(int slot, @Nonnull ItemStack stack)
+		{
+			return true;
+		}
+	}
 }

--- a/src/main/java/dev/gigaherz/enderrift/rift/RiftBlockEntity.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/RiftBlockEntity.java
@@ -31,349 +31,349 @@ import java.util.UUID;
 
 public class RiftBlockEntity extends BlockEntity implements IRiftChangeListener
 {
-	private static final int STARTUP_POWER = 10000;
-	public static final int BUFFER_POWER = 1000000;
-	private final Random rand = new Random();
+    private static final int STARTUP_POWER = 10000;
+    public static final int BUFFER_POWER = 1000000;
+    private final Random rand = new Random();
 
-	private EnergyBuffer energyBuffer = new EnergyBuffer(BUFFER_POWER);
+    private EnergyBuffer energyBuffer = new EnergyBuffer(BUFFER_POWER);
 
-	private boolean powered;
-	private RiftHolder holder;
-	private boolean listenerState;
+    private boolean powered;
+    private RiftHolder holder;
+    private boolean listenerState;
 
-	// Client-side, for rendering
-	private float lastPoweringState;
-	private float poweringState;
-	private boolean poweringStartParticlesSpawned = false;
-	// End of Client-side fields
+    // Client-side, for rendering
+    private float lastPoweringState;
+    private float poweringState;
+    private boolean poweringStartParticlesSpawned = false;
+    // End of Client-side fields
 
-	public PoweredInventory poweredInventory = new PoweredInventory();
-	public LazyOptional<IItemHandler> poweredInventoryProvider = LazyOptional.of(() -> poweredInventory);
+    public PoweredInventory poweredInventory = new PoweredInventory();
+    public LazyOptional<IItemHandler> poweredInventoryProvider = LazyOptional.of(() -> poweredInventory);
 
-	public RiftBlockEntity(BlockPos pos, BlockState state)
-	{
-		super(EnderRiftMod.RIFT_BLOCK_ENTITY.get(), pos, state);
-	}
+    public RiftBlockEntity(BlockPos pos, BlockState state)
+    {
+        super(EnderRiftMod.RIFT_BLOCK_ENTITY.get(), pos, state);
+    }
 
-	public Optional<IEnergyStorage> getEnergyBuffer()
-	{
-		return Optional.of(energyBuffer);
-	}
+    public Optional<IEnergyStorage> getEnergyBuffer()
+    {
+        return Optional.of(energyBuffer);
+    }
 
-	public void tick()
-	{
-		if (level.isClientSide)
-		{
-			lastPoweringState = poweringState;
-			if (powered)
-			{
-				if (!poweringStartParticlesSpawned)
-				{
-					poweringStartParticlesSpawned = true;
+    public void tick()
+    {
+        if (level.isClientSide)
+        {
+            lastPoweringState = poweringState;
+            if (powered)
+            {
+                if (!poweringStartParticlesSpawned)
+                {
+                    poweringStartParticlesSpawned = true;
 
-					for (int i = 0; i < 32; ++i)
-					{
-						this.level.addParticle(ParticleTypes.CRIT, this.worldPosition.getX() + 0.5, this.worldPosition.getY() + 0.5, this.worldPosition.getZ() + 0.5, this.rand.nextGaussian(), this.rand.nextGaussian(), this.rand.nextGaussian());
-						this.level.addParticle(ParticleTypes.PORTAL, this.worldPosition.getX() + 0.5, this.worldPosition.getY() + 0.5, this.worldPosition.getZ() + 0.5, this.rand.nextGaussian(), this.rand.nextGaussian(), this.rand.nextGaussian());
-					}
-				}
-				if (poweringState < 1)
-					poweringState += 0.1f;
-				else
-					poweringState = 1;
-			} else
-			{
-				poweringStartParticlesSpawned = false;
-				if (poweringState > 0)
-					poweringState -= 0.02f;
-				else
-					poweringState = 0;
-			}
-			return;
-		}
+                    for (int i = 0; i < 32; ++i)
+                    {
+                        this.level.addParticle(ParticleTypes.CRIT, this.worldPosition.getX() + 0.5, this.worldPosition.getY() + 0.5, this.worldPosition.getZ() + 0.5, this.rand.nextGaussian(), this.rand.nextGaussian(), this.rand.nextGaussian());
+                        this.level.addParticle(ParticleTypes.PORTAL, this.worldPosition.getX() + 0.5, this.worldPosition.getY() + 0.5, this.worldPosition.getZ() + 0.5, this.rand.nextGaussian(), this.rand.nextGaussian(), this.rand.nextGaussian());
+                    }
+                }
+                if (poweringState < 1)
+                    poweringState += 0.1f;
+                else
+                    poweringState = 1;
+            } else
+            {
+                poweringStartParticlesSpawned = false;
+                if (poweringState > 0)
+                    poweringState -= 0.02f;
+                else
+                    poweringState = 0;
+            }
+            return;
+        }
 
-		int energyUsage = getEnergyUsage();
-		int energyStored = energyBuffer.getEnergyStored();
-		if (energyStored > energyBuffer.getMaxEnergyStored())
-		{
-			energyStored = energyBuffer.getMaxEnergyStored();
-			energyBuffer.setEnergy(energyStored);
-		}
+        int energyUsage = getEnergyUsage();
+        int energyStored = energyBuffer.getEnergyStored();
+        if (energyStored > energyBuffer.getMaxEnergyStored())
+        {
+            energyStored = energyBuffer.getMaxEnergyStored();
+            energyBuffer.setEnergy(energyStored);
+        }
 
-		if (energyStored > energyUsage && !level.hasNeighborSignal(worldPosition))
-		{
-			if (powered)
-			{
-				energyBuffer.setEnergy(energyStored - energyUsage);
-			} else if (energyStored >= STARTUP_POWER)
-			{
-				powered = true;
-				energyBuffer.setEnergy(energyStored - STARTUP_POWER);
-				BlockState state = level.getBlockState(worldPosition);
-				level.sendBlockUpdated(worldPosition, state, state, 3);
-			}
-		} else
-		{
-			powered = false;
-			BlockState state = level.getBlockState(worldPosition);
-			level.sendBlockUpdated(worldPosition, state, state, 3);
-		}
-	}
+        if (energyStored > energyUsage && !level.hasNeighborSignal(worldPosition))
+        {
+            if (powered)
+            {
+                energyBuffer.setEnergy(energyStored - energyUsage);
+            } else if (energyStored >= STARTUP_POWER)
+            {
+                powered = true;
+                energyBuffer.setEnergy(energyStored - STARTUP_POWER);
+                BlockState state = level.getBlockState(worldPosition);
+                level.sendBlockUpdated(worldPosition, state, state, 3);
+            }
+        } else
+        {
+            powered = false;
+            BlockState state = level.getBlockState(worldPosition);
+            level.sendBlockUpdated(worldPosition, state, state, 3);
+        }
+    }
 
-	public void assemble(RiftHolder holder)
-	{
-		this.holder = holder;
-		listenerState = false;
-		setChanged();
-	}
+    public void assemble(RiftHolder holder)
+    {
+        this.holder = holder;
+        listenerState = false;
+        setChanged();
+    }
 
-	public void unassemble()
-	{
-		holder = null;
-		listenerState = false;
-		setChanged();
-	}
+    public void unassemble()
+    {
+        holder = null;
+        listenerState = false;
+        setChanged();
+    }
 
-	@Nullable
-	public RiftInventory getInventory()
-	{
-		if (holder == null)
-			return null;
+    @Nullable
+    public RiftInventory getInventory()
+    {
+        if (holder == null)
+            return null;
 
-		if (!listenerState && level != null && !level.isClientSide)
-		{
-			holder.getInventoryOrCreate().addWeakListener(this);
-			listenerState = true;
-		}
-		return holder.getInventory();
-	}
+        if (!listenerState && level != null && !level.isClientSide)
+        {
+            holder.getInventoryOrCreate().addWeakListener(this);
+            listenerState = true;
+        }
+        return holder.getInventory();
+    }
 
-	public int countInventoryStacks()
-	{
-		IItemHandler handler = getInventory();
-		return handler == null ? 0 : (handler.getSlots() - 1);
-	}
+    public int countInventoryStacks()
+    {
+        IItemHandler handler = getInventory();
+        return handler == null ? 0 : (handler.getSlots() - 1);
+    }
 
-	public ItemStack getRiftItem()
-	{
-		ItemStack stack = new ItemStack(EnderRiftMod.RIFT_ORB.get());
+    public ItemStack getRiftItem()
+    {
+        ItemStack stack = new ItemStack(EnderRiftMod.RIFT_ORB.get());
 
-		CompoundTag tag = new CompoundTag();
+        CompoundTag tag = new CompoundTag();
 
-		tag.putUUID("RiftId", holder.getId());
+        tag.putUUID("RiftId", holder.getId());
 
-		stack.setTag(tag);
+        stack.setTag(tag);
 
-		return stack;
-	}
+        return stack;
+    }
 
-	@Override
-	public void load(CompoundTag compound)
-	{
-		super.load(compound);
+    @Override
+    public void load(CompoundTag compound)
+    {
+        super.load(compound);
 
-		energyBuffer.deserializeNBT(compound.get("Energy"));
-		powered = compound.getBoolean("Powered");
-		if (compound.contains("RiftId"))
-		{
-			RiftStorage storage = RiftStorage.get();
-			UUID id = compound.hasUUID("RiftId") ? compound.getUUID("RiftId") : storage.getMigration(RiftMigration_17_08_2022.class).getMigratedId(compound.getInt("RiftId"));
-			holder = storage.getRift(id);
-		}
-	}
+        energyBuffer.deserializeNBT(compound.get("Energy"));
+        powered = compound.getBoolean("Powered");
+        if (compound.contains("RiftId"))
+        {
+            RiftStorage storage = RiftStorage.get();
+            UUID id = compound.hasUUID("RiftId") ? compound.getUUID("RiftId") : storage.getMigration(RiftMigration_17_08_2022.class).getMigratedId(compound.getInt("RiftId"));
+            holder = storage.getRift(id);
+        }
+    }
 
-	@Override
-	protected void saveAdditional(CompoundTag compound)
-	{
-		super.saveAdditional(compound);
+    @Override
+    protected void saveAdditional(CompoundTag compound)
+    {
+        super.saveAdditional(compound);
 
-		compound.put("Energy", energyBuffer.serializeNBT());
-		compound.putBoolean("Powered", powered);
-		compound.remove("RiftId");
-		if (holder != null)
-		{
-			compound.putUUID("RiftId", holder.getId());
-		}
-	}
+        compound.put("Energy", energyBuffer.serializeNBT());
+        compound.putBoolean("Powered", powered);
+        compound.remove("RiftId");
+        if (holder != null)
+        {
+            compound.putUUID("RiftId", holder.getId());
+        }
+    }
 
-	@Override
-	public CompoundTag getUpdateTag()
-	{
-		CompoundTag tag = super.getUpdateTag();
-		tag.putBoolean("Powered", powered);
-		return tag;
-	}
+    @Override
+    public CompoundTag getUpdateTag()
+    {
+        CompoundTag tag = super.getUpdateTag();
+        tag.putBoolean("Powered", powered);
+        return tag;
+    }
 
-	@Override
-	public void handleUpdateTag(CompoundTag tag)
-	{
-		powered = tag.getBoolean("Powered");
-	}
+    @Override
+    public void handleUpdateTag(CompoundTag tag)
+    {
+        powered = tag.getBoolean("Powered");
+    }
 
-	@Nullable
-	@Override
-	public ClientboundBlockEntityDataPacket getUpdatePacket()
-	{
-		return ClientboundBlockEntityDataPacket.create(this);
-	}
+    @Nullable
+    @Override
+    public ClientboundBlockEntityDataPacket getUpdatePacket()
+    {
+        return ClientboundBlockEntityDataPacket.create(this);
+    }
 
-	@Override
-	public void onDataPacket(Connection net, ClientboundBlockEntityDataPacket pkt)
-	{
-		handleUpdateTag(pkt.getTag());
-	}
+    @Override
+    public void onDataPacket(Connection net, ClientboundBlockEntityDataPacket pkt)
+    {
+        handleUpdateTag(pkt.getTag());
+    }
 
-	@Nonnull
-	@Override
-	public <T> LazyOptional<T> getCapability(@Nonnull final Capability<T> cap, final @Nullable Direction side)
-	{
-		if (cap == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
-			return poweredInventoryProvider.cast();
-		return super.getCapability(cap, side);
-	}
+    @Nonnull
+    @Override
+    public <T> LazyOptional<T> getCapability(@Nonnull final Capability<T> cap, final @Nullable Direction side)
+    {
+        if (cap == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
+            return poweredInventoryProvider.cast();
+        return super.getCapability(cap, side);
+    }
 
-	public ItemStack chooseRandomStack()
-	{
-		IItemHandler handler = getInventory();
-		if (handler == null)
-			return ItemStack.EMPTY;
+    public ItemStack chooseRandomStack()
+    {
+        IItemHandler handler = getInventory();
+        if (handler == null)
+            return ItemStack.EMPTY;
 
-		int max = handler.getSlots();
+        int max = handler.getSlots();
 
-		if (max <= 0)
-			return ItemStack.EMPTY;
+        if (max <= 0)
+            return ItemStack.EMPTY;
 
-		int slot = rand.nextInt(max);
+        int slot = rand.nextInt(max);
 
-		return poweredInventory.getStackInSlot(slot);
-	}
+        return poweredInventory.getStackInSlot(slot);
+    }
 
-	public UUID getRiftId()
-	{
-		if (holder == null)
-		{
-			return null;
-		}
-		return holder.getId();
-	}
+    public UUID getRiftId()
+    {
+        if (holder == null)
+        {
+            return null;
+        }
+        return holder.getId();
+    }
 
-	public int getEnergyUsage()
-	{
-		IItemHandler handler = getInventory();
-		if (handler == null)
-			return 0;
-		return Mth.ceil(Math.pow(handler.getSlots(), 0.8));
-	}
+    public int getEnergyUsage()
+    {
+        IItemHandler handler = getInventory();
+        if (handler == null)
+            return 0;
+        return Mth.ceil(Math.pow(handler.getSlots(), 0.8));
+    }
 
-	public boolean isPowered()
-	{
-		return powered;
-	}
+    public boolean isPowered()
+    {
+        return powered;
+    }
 
-	public float getPoweringState()
-	{
-		return poweringState;
-	}
+    public float getPoweringState()
+    {
+        return poweringState;
+    }
 
-	public float getLastPoweringState()
-	{
-		return lastPoweringState;
-	}
+    public float getLastPoweringState()
+    {
+        return lastPoweringState;
+    }
 
-	@Override
-	public boolean isInvalid()
-	{
-		return isRemoved();
-	}
+    @Override
+    public boolean isInvalid()
+    {
+        return isRemoved();
+    }
 
-	@Override
-	public void onRiftChanged()
-	{
-		setChanged();
-	}
+    @Override
+    public void onRiftChanged()
+    {
+        setChanged();
+    }
 
-	@Override
-	public Optional<Level> getRiftLevel()
-	{
-		return Optional.ofNullable(getLevel());
-	}
+    @Override
+    public Optional<Level> getRiftLevel()
+    {
+        return Optional.ofNullable(getLevel());
+    }
 
-	@Override
-	public Optional<BlockPos> getLocation()
-	{
-		return Optional.ofNullable(getBlockPos());
-	}
+    @Override
+    public Optional<BlockPos> getLocation()
+    {
+        return Optional.ofNullable(getBlockPos());
+    }
 
-	public static void tickStatic(Level level, BlockPos blockPos, BlockState blockState, RiftBlockEntity te)
-	{
-		te.tick();
-	}
+    public static void tickStatic(Level level, BlockPos blockPos, BlockState blockState, RiftBlockEntity te)
+    {
+        te.tick();
+    }
 
-	public class PoweredInventory implements IItemHandler
-	{
-		public long getCount(int slot)
-		{
-			RiftInventory inventory = getInventory();
-			if (inventory == null)
-			{
-				return 0;
-			}
-			return inventory.getCount(slot);
-		}
+    public class PoweredInventory implements IItemHandler
+    {
+        public long getCount(int slot)
+        {
+            RiftInventory inventory = getInventory();
+            if (inventory == null)
+            {
+                return 0;
+            }
+            return inventory.getCount(slot);
+        }
 
-		@Override
-		public int getSlots()
-		{
-			IItemHandler handler = getInventory();
-			if (handler == null)
-				return 0;
+        @Override
+        public int getSlots()
+        {
+            IItemHandler handler = getInventory();
+            if (handler == null)
+                return 0;
 
-			return handler.getSlots();
-		}
+            return handler.getSlots();
+        }
 
-		@Override
-		public ItemStack getStackInSlot(int slot)
-		{
-			if (!powered)
-				return ItemStack.EMPTY;
-			IItemHandler handler = getInventory();
-			if (handler == null)
-				return ItemStack.EMPTY;
-			return handler.getStackInSlot(slot);
-		}
+        @Override
+        public ItemStack getStackInSlot(int slot)
+        {
+            if (!powered)
+                return ItemStack.EMPTY;
+            IItemHandler handler = getInventory();
+            if (handler == null)
+                return ItemStack.EMPTY;
+            return handler.getStackInSlot(slot);
+        }
 
-		@Override
-		public ItemStack insertItem(int slot, ItemStack stack, boolean simulate)
-		{
-			if (!powered)
-				return stack;
-			IItemHandler handler = getInventory();
-			if (handler == null)
-				return stack;
-			return handler.insertItem(slot, stack, simulate);
-		}
+        @Override
+        public ItemStack insertItem(int slot, ItemStack stack, boolean simulate)
+        {
+            if (!powered)
+                return stack;
+            IItemHandler handler = getInventory();
+            if (handler == null)
+                return stack;
+            return handler.insertItem(slot, stack, simulate);
+        }
 
-		@Override
-		public ItemStack extractItem(int slot, int amount, boolean simulate)
-		{
-			if (!powered)
-				return ItemStack.EMPTY;
-			IItemHandler handler = getInventory();
-			if (handler == null)
-				return ItemStack.EMPTY;
-			return handler.extractItem(slot, amount, simulate);
-		}
+        @Override
+        public ItemStack extractItem(int slot, int amount, boolean simulate)
+        {
+            if (!powered)
+                return ItemStack.EMPTY;
+            IItemHandler handler = getInventory();
+            if (handler == null)
+                return ItemStack.EMPTY;
+            return handler.extractItem(slot, amount, simulate);
+        }
 
-		@Override
-		public int getSlotLimit(int slot)
-		{
-			return 64;
-		}
+        @Override
+        public int getSlotLimit(int slot)
+        {
+            return 64;
+        }
 
-		@Override
-		public boolean isItemValid(int slot, @Nonnull ItemStack stack)
-		{
-			return true;
-		}
-	}
+        @Override
+        public boolean isItemValid(int slot, @Nonnull ItemStack stack)
+        {
+            return true;
+        }
+    }
 }

--- a/src/main/java/dev/gigaherz/enderrift/rift/RiftBlockEntity.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/RiftBlockEntity.java
@@ -81,7 +81,8 @@ public class RiftBlockEntity extends BlockEntity implements IRiftChangeListener
                     poweringState += 0.1f;
                 else
                     poweringState = 1;
-            } else
+            }
+            else
             {
                 poweringStartParticlesSpawned = false;
                 if (poweringState > 0)
@@ -105,14 +106,16 @@ public class RiftBlockEntity extends BlockEntity implements IRiftChangeListener
             if (powered)
             {
                 energyBuffer.setEnergy(energyStored - energyUsage);
-            } else if (energyStored >= STARTUP_POWER)
+            }
+            else if (energyStored >= STARTUP_POWER)
             {
                 powered = true;
                 energyBuffer.setEnergy(energyStored - STARTUP_POWER);
                 BlockState state = level.getBlockState(worldPosition);
                 level.sendBlockUpdated(worldPosition, state, state, 3);
             }
-        } else
+        }
+        else
         {
             powered = false;
             BlockState state = level.getBlockState(worldPosition);

--- a/src/main/java/dev/gigaherz/enderrift/rift/RiftItem.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/RiftItem.java
@@ -17,8 +17,6 @@ import net.minecraft.world.level.Level;
 import javax.annotation.Nullable;
 import java.util.List;
 
-import net.minecraft.world.item.Item.Properties;
-
 public class RiftItem extends Item
 {
     public RiftItem(Properties properties)
@@ -42,7 +40,7 @@ public class RiftItem extends Item
         CompoundTag tag = stack.getTag();
         if (tag != null && tag.contains("RiftId"))
         {
-            tooltip.add(Component.translatable("text.enderrift.tooltip.riftid", tag.getInt("RiftId")));
+            tooltip.add(Component.translatable("text.enderrift.tooltip.riftid", tag.getUUID("RiftId")));
         }
     }
 

--- a/src/main/java/dev/gigaherz/enderrift/rift/RiftItem.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/RiftItem.java
@@ -1,6 +1,8 @@
 package dev.gigaherz.enderrift.rift;
 
 import dev.gigaherz.enderrift.EnderRiftMod;
+import dev.gigaherz.enderrift.rift.storage.RiftStorage;
+import dev.gigaherz.enderrift.rift.storage.migration.RiftMigration_17_08_2022;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.entity.player.Player;
@@ -8,6 +10,7 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.Tag;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.core.Direction;
 import net.minecraft.core.BlockPos;
@@ -16,6 +19,7 @@ import net.minecraft.world.level.Level;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.UUID;
 
 public class RiftItem extends Item
 {
@@ -33,7 +37,21 @@ public class RiftItem extends Item
         else
             return this.getDescriptionId() + ".bound";
     }
-
+    
+    @Override
+    public void verifyTagAfterLoad(CompoundTag tag)
+    {
+        if(RiftStorage.isAvailable() && tag.contains("RiftId", Tag.TAG_ANY_NUMERIC)) 
+        {
+            UUID id = RiftStorage.get().getMigration(RiftMigration_17_08_2022.class).getMigratedId(tag.getInt("RiftId"));
+            tag.remove("RiftId");
+            if(id != null) 
+            {
+                tag.putUUID("RiftId", id);
+            }
+        }
+    }
+    
     @Override
     public void appendHoverText(ItemStack stack, @Nullable Level worldIn, List<Component> tooltip, TooltipFlag flagIn)
     {

--- a/src/main/java/dev/gigaherz/enderrift/rift/RiftStructure.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/RiftStructure.java
@@ -24,62 +24,62 @@ public class RiftStructure
 
     public static void init()
     {
-        StructurePattern = new Block[]
-        {
+        StructurePattern = new Block[]{
                 // Bottom
-                Blocks.IRON_BLOCK, Blocks.REDSTONE_BLOCK, Blocks.IRON_BLOCK, 
-                Blocks.REDSTONE_BLOCK, null, Blocks.REDSTONE_BLOCK, 
+                Blocks.IRON_BLOCK, Blocks.REDSTONE_BLOCK, Blocks.IRON_BLOCK,
+                Blocks.REDSTONE_BLOCK, null, Blocks.REDSTONE_BLOCK,
                 Blocks.IRON_BLOCK, Blocks.REDSTONE_BLOCK, Blocks.IRON_BLOCK,
 
                 // Middle
-                Blocks.REDSTONE_BLOCK, null, Blocks.REDSTONE_BLOCK, 
-                null, EnderRiftMod.RIFT.get(), null, 
+                Blocks.REDSTONE_BLOCK, null, Blocks.REDSTONE_BLOCK,
+                null, EnderRiftMod.RIFT.get(), null,
                 Blocks.REDSTONE_BLOCK, null, Blocks.REDSTONE_BLOCK,
 
                 // Top
-                Blocks.IRON_BLOCK, Blocks.REDSTONE_BLOCK, Blocks.IRON_BLOCK, 
-                Blocks.REDSTONE_BLOCK, null, Blocks.REDSTONE_BLOCK, 
-                Blocks.IRON_BLOCK, Blocks.REDSTONE_BLOCK, Blocks.IRON_BLOCK, };
+                Blocks.IRON_BLOCK, Blocks.REDSTONE_BLOCK, Blocks.IRON_BLOCK,
+                Blocks.REDSTONE_BLOCK, null, Blocks.REDSTONE_BLOCK,
+                Blocks.IRON_BLOCK, Blocks.REDSTONE_BLOCK, Blocks.IRON_BLOCK,
+        };
 
-        StructureStates = new BlockState[]
-        {
+        StructureStates = new BlockState[]{
 
                 // Bottom
-                EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.NW, true), 
-                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.X, true), 
+                EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.NW, true),
+                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.X, true),
                 EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.NE, true),
 
-                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Z, true), 
-                null, 
+                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Z, true),
+                null,
                 EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Z, true),
 
-                EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.SW, true), 
+                EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.SW, true),
                 EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.X, true),
                 EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.SE, true),
 
                 // Middle
-                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Y, false), 
-                null, 
+                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Y, false),
+                null,
                 EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Y, false),
 
                 null, null, null,
 
-                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Y, false), 
-                null, 
+                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Y, false),
+                null,
                 EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Y, false),
 
                 // Top
-                EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.NW, false), 
-                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.X, false), 
+                EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.NW, false),
+                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.X, false),
                 EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.NE, false),
 
-                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Z, false), 
-                null, 
+                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Z, false),
+                null,
                 EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Z, false),
 
-                EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.SW, false), 
-                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.X, false), 
-                EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.SE, false), };
+                EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.SW, false),
+                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.X, false),
+                EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.SE, false),
+        };
     }
 
     public static boolean duplicateOrb(Level world, BlockPos pos, Player player)
@@ -141,7 +141,7 @@ public class RiftStructure
                             BlockState st = world.getBlockState(bp);
                             if (!st.isAir())
                                 return false;
-                        } 
+                        }
                         else if (b != EnderRiftMod.RIFT.get())
                         {
                             if (b != w)
@@ -233,11 +233,11 @@ public class RiftStructure
         if (state.getBlock() == EnderRiftMod.STRUCTURE_CORNER.get())
         {
             return StructurePattern[0];
-        } 
+        }
         else if (state.getBlock() == EnderRiftMod.STRUCTURE_EDGE.get())
         {
             return StructurePattern[1];
-        } 
+        }
         else
         {
             return StructurePattern[13];

--- a/src/main/java/dev/gigaherz/enderrift/rift/RiftStructure.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/RiftStructure.java
@@ -1,5 +1,7 @@
 package dev.gigaherz.enderrift.rift;
 
+import java.util.UUID;
+
 import dev.gigaherz.enderrift.EnderRiftMod;
 import dev.gigaherz.enderrift.rift.storage.RiftStorage;
 import net.minecraft.core.Direction;
@@ -15,74 +17,90 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 
-public class RiftStructure
-{
+public class RiftStructure {
     static Block[] StructurePattern;
     static BlockState[] StructureStates;
 
-    public static void init()
-    {
-        StructurePattern = new Block[]{
-                // Bottom
-                Blocks.IRON_BLOCK, Blocks.REDSTONE_BLOCK, Blocks.IRON_BLOCK,
-                Blocks.REDSTONE_BLOCK, null, Blocks.REDSTONE_BLOCK,
-                Blocks.IRON_BLOCK, Blocks.REDSTONE_BLOCK, Blocks.IRON_BLOCK,
+    public static void init() {
+        StructurePattern = new Block[] {
+            // Bottom
+            Blocks.IRON_BLOCK,
+            Blocks.REDSTONE_BLOCK,
+            Blocks.IRON_BLOCK,
+            Blocks.REDSTONE_BLOCK,
+            null,
+            Blocks.REDSTONE_BLOCK,
+            Blocks.IRON_BLOCK,
+            Blocks.REDSTONE_BLOCK,
+            Blocks.IRON_BLOCK,
 
-                // Middle
-                Blocks.REDSTONE_BLOCK, null, Blocks.REDSTONE_BLOCK,
-                null, EnderRiftMod.RIFT.get(), null,
-                Blocks.REDSTONE_BLOCK, null, Blocks.REDSTONE_BLOCK,
+            // Middle
+            Blocks.REDSTONE_BLOCK,
+            null,
+            Blocks.REDSTONE_BLOCK,
+            null,
+            EnderRiftMod.RIFT.get(),
+            null,
+            Blocks.REDSTONE_BLOCK,
+            null,
+            Blocks.REDSTONE_BLOCK,
 
-                // Top
-                Blocks.IRON_BLOCK, Blocks.REDSTONE_BLOCK, Blocks.IRON_BLOCK,
-                Blocks.REDSTONE_BLOCK, null, Blocks.REDSTONE_BLOCK,
-                Blocks.IRON_BLOCK, Blocks.REDSTONE_BLOCK, Blocks.IRON_BLOCK,
+            // Top
+            Blocks.IRON_BLOCK,
+            Blocks.REDSTONE_BLOCK,
+            Blocks.IRON_BLOCK,
+            Blocks.REDSTONE_BLOCK,
+            null,
+            Blocks.REDSTONE_BLOCK,
+            Blocks.IRON_BLOCK,
+            Blocks.REDSTONE_BLOCK,
+            Blocks.IRON_BLOCK,
         };
 
-        StructureStates = new BlockState[]{
+        StructureStates = new BlockState[] {
 
-                // Bottom
-                EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.NW, true),
-                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.X, true),
-                EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.NE, true),
+            // Bottom
+            EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.NW, true),
+            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.X, true),
+            EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.NE, true),
 
+            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Z, true),
+            null,
+            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Z, true),
 
-                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Z, true),
-                null,
-                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Z, true),
+            EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.SW, true),
+            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.X, true),
+            EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.SE, true),
 
-                EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.SW, true),
-                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.X, true),
-                EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.SE, true),
+            // Middle
+            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Y, false),
+            null,
+            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Y, false),
 
-                // Middle
-                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Y, false),
-                null,
-                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Y, false),
+            null,
+            null,
+            null,
 
-                null, null, null,
+            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Y, false),
+            null,
+            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Y, false),
 
-                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Y, false),
-                null,
-                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Y, false),
+            // Top
+            EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.NW, false),
+            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.X, false),
+            EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.NE, false),
 
-                // Top
-                EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.NW, false),
-                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.X, false),
-                EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.NE, false),
+            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Z, false),
+            null,
+            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Z, false),
 
-                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Z, false),
-                null,
-                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Z, false),
-
-                EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.SW, false),
-                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.X, false),
-                EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.SE, false),
+            EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.SW, false),
+            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.X, false),
+            EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.SE, false),
         };
     }
 
-    public static boolean duplicateOrb(Level world, BlockPos pos, Player player)
-    {
+    public static boolean duplicateOrb(Level world, BlockPos pos, Player player) {
         BlockEntity te = world.getBlockEntity(pos);
 
         if (!(te instanceof RiftBlockEntity))
@@ -95,17 +113,12 @@ public class RiftStructure
         return true;
     }
 
-    public static void breakStructure(Level world, BlockPos pos)
-    {
-        for (int yy = -1; yy <= 1; yy++)
-        {
-            for (int xx = -1; xx <= 1; xx++)
-            {
-                for (int zz = -1; zz <= 1; zz++)
-                {
+    public static void breakStructure(Level world, BlockPos pos) {
+        for (int yy = -1; yy <= 1; yy++) {
+            for (int xx = -1; xx <= 1; xx++) {
+                for (int zz = -1; zz <= 1; zz++) {
                     BlockPos pos2 = pos.offset(xx, yy, zz);
-                    if (world.getBlockState(pos2).getBlock() == EnderRiftMod.RIFT.get())
-                    {
+                    if (world.getBlockState(pos2).getBlock() == EnderRiftMod.RIFT.get()) {
                         RiftStructure.dismantle(world, pos2);
                         return;
                     }
@@ -114,8 +127,7 @@ public class RiftStructure
         }
     }
 
-    public static boolean assemble(Level world, BlockPos pos, ItemStack itemStack)
-    {
+    public static boolean assemble(Level world, BlockPos pos, ItemStack itemStack) {
         BlockState state = world.getBlockState(pos);
 
         if (state.getBlock() != EnderRiftMod.RIFT.get())
@@ -124,25 +136,18 @@ public class RiftStructure
         if (state.getValue(RiftBlock.ASSEMBLED))
             return false;
 
-        for (int yy = 0; yy <= 2; yy++)
-        {
-            for (int zz = 0; zz <= 2; zz++)
-            {
-                for (int xx = 0; xx <= 2; xx++)
-                {
+        for (int yy = 0; yy <= 2; yy++) {
+            for (int zz = 0; zz <= 2; zz++) {
+                for (int xx = 0; xx <= 2; xx++) {
                     BlockPos bp = pos.offset(xx - 1, yy - 1, zz - 1);
                     Block b = StructurePattern[yy * 9 + zz * 3 + xx];
                     Block w = world.getBlockState(bp).getBlock();
-                    if (b != null)
-                    {
-                        if (b == Blocks.AIR)
-                        {
+                    if (b != null) {
+                        if (b == Blocks.AIR) {
                             BlockState st = world.getBlockState(bp);
                             if (!st.isAir())
                                 return false;
-                        }
-                        else if (b != EnderRiftMod.RIFT.get())
-                        {
+                        } else if (b != EnderRiftMod.RIFT.get()) {
                             if (b != w)
                                 return false;
                         }
@@ -156,14 +161,10 @@ public class RiftStructure
         return true;
     }
 
-    private static void buildStructure(Level world, BlockPos pos, ItemStack itemStack, BlockState state)
-    {
-        for (int yy = 0; yy <= 2; yy++)
-        {
-            for (int zz = 0; zz <= 2; zz++)
-            {
-                for (int xx = 0; xx <= 2; xx++)
-                {
+    private static void buildStructure(Level world, BlockPos pos, ItemStack itemStack, BlockState state) {
+        for (int yy = 0; yy <= 2; yy++) {
+            for (int zz = 0; zz <= 2; zz++) {
+                for (int xx = 0; xx <= 2; xx++) {
                     BlockState bs = StructureStates[yy * 9 + zz * 3 + xx];
                     if (bs == null)
                         continue;
@@ -180,27 +181,22 @@ public class RiftStructure
 
         CompoundTag tagCompound = itemStack.getTag();
 
-        if (tagCompound != null && tagCompound.contains("RiftId"))
-        {
-            rift.assemble(tagCompound.getInt("RiftId"));
+        if (tagCompound != null && tagCompound.contains("RiftId")) {
+            UUID id = tagCompound.getUUID("RiftId");
+            if (id != null) {
+                rift.assemble(RiftStorage.get().getRift(id));
+                return;
+            }
         }
-        else
-        {
-            rift.assemble(RiftStorage.get(world).getNextRiftId());
-        }
+        rift.assemble(RiftStorage.get().newRift());
     }
 
-    public static void dismantle(Level world, BlockPos pos)
-    {
-        for (int yy = 0; yy <= 2; yy++)
-        {
-            for (int zz = 0; zz <= 2; zz++)
-            {
-                for (int xx = 0; xx <= 2; xx++)
-                {
+    public static void dismantle(Level world, BlockPos pos) {
+        for (int yy = 0; yy <= 2; yy++) {
+            for (int zz = 0; zz <= 2; zz++) {
+                for (int xx = 0; xx <= 2; xx++) {
                     Block b = StructurePattern[yy * 9 + zz * 3 + xx];
-                    if (b != null && b != Blocks.AIR && b != EnderRiftMod.RIFT.get())
-                    {
+                    if (b != null && b != Blocks.AIR && b != EnderRiftMod.RIFT.get()) {
                         BlockPos bp = pos.offset(xx - 1, yy - 1, zz - 1);
                         Block block = world.getBlockState(bp).getBlock();
                         if (block == EnderRiftMod.STRUCTURE_EDGE.get() || block == EnderRiftMod.STRUCTURE_CORNER.get())
@@ -212,8 +208,7 @@ public class RiftStructure
 
         BlockState state = world.getBlockState(pos);
 
-        if (state.getBlock() == EnderRiftMod.RIFT.get() && state.getValue(RiftBlock.ASSEMBLED))
-        {
+        if (state.getBlock() == EnderRiftMod.RIFT.get() && state.getValue(RiftBlock.ASSEMBLED)) {
             world.setBlockAndUpdate(pos, state.setValue(RiftBlock.ASSEMBLED, false));
 
             RiftBlockEntity rift = (RiftBlockEntity) world.getBlockEntity(pos);
@@ -225,33 +220,22 @@ public class RiftStructure
         }
     }
 
-    public static Block getOriginalBlock(BlockState state)
-    {
-        if (state.getBlock() == EnderRiftMod.STRUCTURE_CORNER.get())
-        {
+    public static Block getOriginalBlock(BlockState state) {
+        if (state.getBlock() == EnderRiftMod.STRUCTURE_CORNER.get()) {
             return StructurePattern[0];
-        }
-        else if (state.getBlock() == EnderRiftMod.STRUCTURE_EDGE.get())
-        {
+        } else if (state.getBlock() == EnderRiftMod.STRUCTURE_EDGE.get()) {
             return StructurePattern[1];
-        }
-        else
-        {
+        } else {
             return StructurePattern[13];
         }
     }
 
-    public static Block getOriginalBlock(BlockGetter worldIn, BlockPos pos)
-    {
-        for (int yy = 0; yy <= 2; yy++)
-        {
-            for (int zz = 0; zz <= 2; zz++)
-            {
-                for (int xx = 0; xx <= 2; xx++)
-                {
+    public static Block getOriginalBlock(BlockGetter worldIn, BlockPos pos) {
+        for (int yy = 0; yy <= 2; yy++) {
+            for (int zz = 0; zz <= 2; zz++) {
+                for (int xx = 0; xx <= 2; xx++) {
                     BlockPos pos2 = pos.offset(1 - xx, 1 - yy, 1 - zz);
-                    if (worldIn.getBlockState(pos2).getBlock() == EnderRiftMod.RIFT.get())
-                    {
+                    if (worldIn.getBlockState(pos2).getBlock() == EnderRiftMod.RIFT.get()) {
                         return StructurePattern[yy * 9 + zz * 3 + xx];
                     }
                 }

--- a/src/main/java/dev/gigaherz/enderrift/rift/RiftStructure.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/RiftStructure.java
@@ -17,71 +17,72 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 
-public class RiftStructure {
+public class RiftStructure
+{
     static Block[] StructurePattern;
     static BlockState[] StructureStates;
 
-    public static void init() 
+    public static void init()
     {
-        StructurePattern = new Block[] {
-        		// Bottom
-                Blocks.IRON_BLOCK, Blocks.REDSTONE_BLOCK, Blocks.IRON_BLOCK,
-                Blocks.REDSTONE_BLOCK, null, Blocks.REDSTONE_BLOCK,
+        StructurePattern = new Block[]
+        {
+                // Bottom
+                Blocks.IRON_BLOCK, Blocks.REDSTONE_BLOCK, Blocks.IRON_BLOCK, 
+                Blocks.REDSTONE_BLOCK, null, Blocks.REDSTONE_BLOCK, 
                 Blocks.IRON_BLOCK, Blocks.REDSTONE_BLOCK, Blocks.IRON_BLOCK,
 
                 // Middle
-                Blocks.REDSTONE_BLOCK, null, Blocks.REDSTONE_BLOCK,
-                null, EnderRiftMod.RIFT.get(), null,
+                Blocks.REDSTONE_BLOCK, null, Blocks.REDSTONE_BLOCK, 
+                null, EnderRiftMod.RIFT.get(), null, 
                 Blocks.REDSTONE_BLOCK, null, Blocks.REDSTONE_BLOCK,
 
                 // Top
-                Blocks.IRON_BLOCK, Blocks.REDSTONE_BLOCK, Blocks.IRON_BLOCK,
-                Blocks.REDSTONE_BLOCK, null, Blocks.REDSTONE_BLOCK,
-                Blocks.IRON_BLOCK, Blocks.REDSTONE_BLOCK, Blocks.IRON_BLOCK,
-        };
+                Blocks.IRON_BLOCK, Blocks.REDSTONE_BLOCK, Blocks.IRON_BLOCK, 
+                Blocks.REDSTONE_BLOCK, null, Blocks.REDSTONE_BLOCK, 
+                Blocks.IRON_BLOCK, Blocks.REDSTONE_BLOCK, Blocks.IRON_BLOCK, };
 
-        StructureStates = new BlockState[] {
+        StructureStates = new BlockState[]
+        {
 
                 // Bottom
-                EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.NW, true),
-                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.X, true),
+                EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.NW, true), 
+                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.X, true), 
                 EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.NE, true),
 
-                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Z, true),
-                null,
+                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Z, true), 
+                null, 
                 EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Z, true),
 
-                EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.SW, true),
+                EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.SW, true), 
                 EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.X, true),
                 EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.SE, true),
 
-            // Middle
-                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Y, false),
-                null,
+                // Middle
+                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Y, false), 
+                null, 
                 EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Y, false),
 
                 null, null, null,
 
-	            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Y, false),
-	            null,
-	            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Y, false),
-	
-	            // Top
-	            EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.NW, false),
-	            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.X, false),
-	            EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.NE, false),
-	
-	            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Z, false),
-	            null,
-	            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Z, false),
-	
-	            EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.SW, false),
-	            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.X, false),
-	            EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.SE, false),
-        };
+                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Y, false), 
+                null, 
+                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Y, false),
+
+                // Top
+                EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.NW, false), 
+                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.X, false), 
+                EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.NE, false),
+
+                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Z, false), 
+                null, 
+                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Z, false),
+
+                EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.SW, false), 
+                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.X, false), 
+                EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.SE, false), };
     }
 
-    public static boolean duplicateOrb(Level world, BlockPos pos, Player player) 
+    public static boolean duplicateOrb(Level world, BlockPos pos, Player player)
     {
         BlockEntity te = world.getBlockEntity(pos);
 
@@ -95,15 +96,16 @@ public class RiftStructure {
         return true;
     }
 
-    public static void breakStructure(Level world, BlockPos pos) {
-        for (int yy = -1; yy <= 1; yy++) 
+    public static void breakStructure(Level world, BlockPos pos)
+    {
+        for (int yy = -1; yy <= 1; yy++)
         {
-            for (int xx = -1; xx <= 1; xx++) 
+            for (int xx = -1; xx <= 1; xx++)
             {
-                for (int zz = -1; zz <= 1; zz++) 
+                for (int zz = -1; zz <= 1; zz++)
                 {
                     BlockPos pos2 = pos.offset(xx, yy, zz);
-                    if (world.getBlockState(pos2).getBlock() == EnderRiftMod.RIFT.get()) 
+                    if (world.getBlockState(pos2).getBlock() == EnderRiftMod.RIFT.get())
                     {
                         RiftStructure.dismantle(world, pos2);
                         return;
@@ -113,7 +115,8 @@ public class RiftStructure {
         }
     }
 
-    public static boolean assemble(Level world, BlockPos pos, ItemStack itemStack) {
+    public static boolean assemble(Level world, BlockPos pos, ItemStack itemStack)
+    {
         BlockState state = world.getBlockState(pos);
 
         if (state.getBlock() != EnderRiftMod.RIFT.get())
@@ -122,23 +125,23 @@ public class RiftStructure {
         if (state.getValue(RiftBlock.ASSEMBLED))
             return false;
 
-        for (int yy = 0; yy <= 2; yy++) 
+        for (int yy = 0; yy <= 2; yy++)
         {
-            for (int zz = 0; zz <= 2; zz++) 
+            for (int zz = 0; zz <= 2; zz++)
             {
-                for (int xx = 0; xx <= 2; xx++) 
+                for (int xx = 0; xx <= 2; xx++)
                 {
                     BlockPos bp = pos.offset(xx - 1, yy - 1, zz - 1);
                     Block b = StructurePattern[yy * 9 + zz * 3 + xx];
                     Block w = world.getBlockState(bp).getBlock();
-                    if (b != null) 
+                    if (b != null)
                     {
-                        if (b == Blocks.AIR) 
+                        if (b == Blocks.AIR)
                         {
                             BlockState st = world.getBlockState(bp);
                             if (!st.isAir())
                                 return false;
-                        } else if (b != EnderRiftMod.RIFT.get()) 
+                        } else if (b != EnderRiftMod.RIFT.get())
                         {
                             if (b != w)
                                 return false;
@@ -153,12 +156,13 @@ public class RiftStructure {
         return true;
     }
 
-    private static void buildStructure(Level world, BlockPos pos, ItemStack itemStack, BlockState state) {
-        for (int yy = 0; yy <= 2; yy++) 
+    private static void buildStructure(Level world, BlockPos pos, ItemStack itemStack, BlockState state)
+    {
+        for (int yy = 0; yy <= 2; yy++)
         {
-            for (int zz = 0; zz <= 2; zz++) 
+            for (int zz = 0; zz <= 2; zz++)
             {
-                for (int xx = 0; xx <= 2; xx++) 
+                for (int xx = 0; xx <= 2; xx++)
                 {
                     BlockState bs = StructureStates[yy * 9 + zz * 3 + xx];
                     if (bs == null)
@@ -176,10 +180,10 @@ public class RiftStructure {
 
         CompoundTag tagCompound = itemStack.getTag();
 
-        if (tagCompound != null && tagCompound.contains("RiftId")) 
+        if (tagCompound != null && tagCompound.contains("RiftId"))
         {
             UUID id = tagCompound.getUUID("RiftId");
-            if (id != null) 
+            if (id != null)
             {
                 rift.assemble(RiftStorage.get().getRift(id));
                 return;
@@ -188,15 +192,16 @@ public class RiftStructure {
         rift.assemble(RiftStorage.get().newRift());
     }
 
-    public static void dismantle(Level world, BlockPos pos) {
-        for (int yy = 0; yy <= 2; yy++) 
+    public static void dismantle(Level world, BlockPos pos)
+    {
+        for (int yy = 0; yy <= 2; yy++)
         {
-            for (int zz = 0; zz <= 2; zz++) 
+            for (int zz = 0; zz <= 2; zz++)
             {
-                for (int xx = 0; xx <= 2; xx++) 
+                for (int xx = 0; xx <= 2; xx++)
                 {
                     Block b = StructurePattern[yy * 9 + zz * 3 + xx];
-                    if (b != null && b != Blocks.AIR && b != EnderRiftMod.RIFT.get()) 
+                    if (b != null && b != Blocks.AIR && b != EnderRiftMod.RIFT.get())
                     {
                         BlockPos bp = pos.offset(xx - 1, yy - 1, zz - 1);
                         Block block = world.getBlockState(bp).getBlock();
@@ -209,7 +214,7 @@ public class RiftStructure {
 
         BlockState state = world.getBlockState(pos);
 
-        if (state.getBlock() == EnderRiftMod.RIFT.get() && state.getValue(RiftBlock.ASSEMBLED)) 
+        if (state.getBlock() == EnderRiftMod.RIFT.get() && state.getValue(RiftBlock.ASSEMBLED))
         {
             world.setBlockAndUpdate(pos, state.setValue(RiftBlock.ASSEMBLED, false));
 
@@ -222,29 +227,30 @@ public class RiftStructure {
         }
     }
 
-    public static Block getOriginalBlock(BlockState state) {
-        if (state.getBlock() == EnderRiftMod.STRUCTURE_CORNER.get()) 
+    public static Block getOriginalBlock(BlockState state)
+    {
+        if (state.getBlock() == EnderRiftMod.STRUCTURE_CORNER.get())
         {
             return StructurePattern[0];
-        } else if (state.getBlock() == EnderRiftMod.STRUCTURE_EDGE.get()) 
+        } else if (state.getBlock() == EnderRiftMod.STRUCTURE_EDGE.get())
         {
             return StructurePattern[1];
-        } else 
+        } else
         {
             return StructurePattern[13];
         }
     }
 
-    public static Block getOriginalBlock(BlockGetter worldIn, BlockPos pos) 
+    public static Block getOriginalBlock(BlockGetter worldIn, BlockPos pos)
     {
-        for (int yy = 0; yy <= 2; yy++) 
+        for (int yy = 0; yy <= 2; yy++)
         {
-            for (int zz = 0; zz <= 2; zz++) 
+            for (int zz = 0; zz <= 2; zz++)
             {
-                for (int xx = 0; xx <= 2; xx++) 
+                for (int xx = 0; xx <= 2; xx++)
                 {
                     BlockPos pos2 = pos.offset(1 - xx, 1 - yy, 1 - zz);
-                    if (worldIn.getBlockState(pos2).getBlock() == EnderRiftMod.RIFT.get()) 
+                    if (worldIn.getBlockState(pos2).getBlock() == EnderRiftMod.RIFT.get())
                     {
                         return StructurePattern[yy * 9 + zz * 3 + xx];
                     }

--- a/src/main/java/dev/gigaherz/enderrift/rift/RiftStructure.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/RiftStructure.java
@@ -21,86 +21,68 @@ public class RiftStructure {
     static Block[] StructurePattern;
     static BlockState[] StructureStates;
 
-    public static void init() {
+    public static void init() 
+    {
         StructurePattern = new Block[] {
-            // Bottom
-            Blocks.IRON_BLOCK,
-            Blocks.REDSTONE_BLOCK,
-            Blocks.IRON_BLOCK,
-            Blocks.REDSTONE_BLOCK,
-            null,
-            Blocks.REDSTONE_BLOCK,
-            Blocks.IRON_BLOCK,
-            Blocks.REDSTONE_BLOCK,
-            Blocks.IRON_BLOCK,
+        		// Bottom
+                Blocks.IRON_BLOCK, Blocks.REDSTONE_BLOCK, Blocks.IRON_BLOCK,
+                Blocks.REDSTONE_BLOCK, null, Blocks.REDSTONE_BLOCK,
+                Blocks.IRON_BLOCK, Blocks.REDSTONE_BLOCK, Blocks.IRON_BLOCK,
 
-            // Middle
-            Blocks.REDSTONE_BLOCK,
-            null,
-            Blocks.REDSTONE_BLOCK,
-            null,
-            EnderRiftMod.RIFT.get(),
-            null,
-            Blocks.REDSTONE_BLOCK,
-            null,
-            Blocks.REDSTONE_BLOCK,
+                // Middle
+                Blocks.REDSTONE_BLOCK, null, Blocks.REDSTONE_BLOCK,
+                null, EnderRiftMod.RIFT.get(), null,
+                Blocks.REDSTONE_BLOCK, null, Blocks.REDSTONE_BLOCK,
 
-            // Top
-            Blocks.IRON_BLOCK,
-            Blocks.REDSTONE_BLOCK,
-            Blocks.IRON_BLOCK,
-            Blocks.REDSTONE_BLOCK,
-            null,
-            Blocks.REDSTONE_BLOCK,
-            Blocks.IRON_BLOCK,
-            Blocks.REDSTONE_BLOCK,
-            Blocks.IRON_BLOCK,
+                // Top
+                Blocks.IRON_BLOCK, Blocks.REDSTONE_BLOCK, Blocks.IRON_BLOCK,
+                Blocks.REDSTONE_BLOCK, null, Blocks.REDSTONE_BLOCK,
+                Blocks.IRON_BLOCK, Blocks.REDSTONE_BLOCK, Blocks.IRON_BLOCK,
         };
 
         StructureStates = new BlockState[] {
 
-            // Bottom
-            EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.NW, true),
-            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.X, true),
-            EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.NE, true),
+                // Bottom
+                EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.NW, true),
+                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.X, true),
+                EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.NE, true),
 
-            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Z, true),
-            null,
-            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Z, true),
+                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Z, true),
+                null,
+                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Z, true),
 
-            EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.SW, true),
-            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.X, true),
-            EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.SE, true),
+                EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.SW, true),
+                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.X, true),
+                EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.SE, true),
 
             // Middle
-            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Y, false),
-            null,
-            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Y, false),
+                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Y, false),
+                null,
+                EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Y, false),
 
-            null,
-            null,
-            null,
+                null, null, null,
 
-            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Y, false),
-            null,
-            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Y, false),
-
-            // Top
-            EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.NW, false),
-            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.X, false),
-            EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.NE, false),
-
-            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Z, false),
-            null,
-            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Z, false),
-
-            EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.SW, false),
-            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.X, false),
-            EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.SE, false),
+	            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Y, false),
+	            null,
+	            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Y, false),
+	
+	            // Top
+	            EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.NW, false),
+	            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.X, false),
+	            EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.NE, false),
+	
+	            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Z, false),
+	            null,
+	            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.Z, false),
+	
+	            EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.SW, false),
+	            EnderRiftMod.STRUCTURE_EDGE.get().edgeState(Direction.Axis.X, false),
+	            EnderRiftMod.STRUCTURE_CORNER.get().cornerState(StructureCornerBlock.Corner.SE, false),
         };
     }
 
-    public static boolean duplicateOrb(Level world, BlockPos pos, Player player) {
+    public static boolean duplicateOrb(Level world, BlockPos pos, Player player) 
+    {
         BlockEntity te = world.getBlockEntity(pos);
 
         if (!(te instanceof RiftBlockEntity))
@@ -114,11 +96,15 @@ public class RiftStructure {
     }
 
     public static void breakStructure(Level world, BlockPos pos) {
-        for (int yy = -1; yy <= 1; yy++) {
-            for (int xx = -1; xx <= 1; xx++) {
-                for (int zz = -1; zz <= 1; zz++) {
+        for (int yy = -1; yy <= 1; yy++) 
+        {
+            for (int xx = -1; xx <= 1; xx++) 
+            {
+                for (int zz = -1; zz <= 1; zz++) 
+                {
                     BlockPos pos2 = pos.offset(xx, yy, zz);
-                    if (world.getBlockState(pos2).getBlock() == EnderRiftMod.RIFT.get()) {
+                    if (world.getBlockState(pos2).getBlock() == EnderRiftMod.RIFT.get()) 
+                    {
                         RiftStructure.dismantle(world, pos2);
                         return;
                     }
@@ -136,18 +122,24 @@ public class RiftStructure {
         if (state.getValue(RiftBlock.ASSEMBLED))
             return false;
 
-        for (int yy = 0; yy <= 2; yy++) {
-            for (int zz = 0; zz <= 2; zz++) {
-                for (int xx = 0; xx <= 2; xx++) {
+        for (int yy = 0; yy <= 2; yy++) 
+        {
+            for (int zz = 0; zz <= 2; zz++) 
+            {
+                for (int xx = 0; xx <= 2; xx++) 
+                {
                     BlockPos bp = pos.offset(xx - 1, yy - 1, zz - 1);
                     Block b = StructurePattern[yy * 9 + zz * 3 + xx];
                     Block w = world.getBlockState(bp).getBlock();
-                    if (b != null) {
-                        if (b == Blocks.AIR) {
+                    if (b != null) 
+                    {
+                        if (b == Blocks.AIR) 
+                        {
                             BlockState st = world.getBlockState(bp);
                             if (!st.isAir())
                                 return false;
-                        } else if (b != EnderRiftMod.RIFT.get()) {
+                        } else if (b != EnderRiftMod.RIFT.get()) 
+                        {
                             if (b != w)
                                 return false;
                         }
@@ -162,9 +154,12 @@ public class RiftStructure {
     }
 
     private static void buildStructure(Level world, BlockPos pos, ItemStack itemStack, BlockState state) {
-        for (int yy = 0; yy <= 2; yy++) {
-            for (int zz = 0; zz <= 2; zz++) {
-                for (int xx = 0; xx <= 2; xx++) {
+        for (int yy = 0; yy <= 2; yy++) 
+        {
+            for (int zz = 0; zz <= 2; zz++) 
+            {
+                for (int xx = 0; xx <= 2; xx++) 
+                {
                     BlockState bs = StructureStates[yy * 9 + zz * 3 + xx];
                     if (bs == null)
                         continue;
@@ -181,9 +176,11 @@ public class RiftStructure {
 
         CompoundTag tagCompound = itemStack.getTag();
 
-        if (tagCompound != null && tagCompound.contains("RiftId")) {
+        if (tagCompound != null && tagCompound.contains("RiftId")) 
+        {
             UUID id = tagCompound.getUUID("RiftId");
-            if (id != null) {
+            if (id != null) 
+            {
                 rift.assemble(RiftStorage.get().getRift(id));
                 return;
             }
@@ -192,11 +189,15 @@ public class RiftStructure {
     }
 
     public static void dismantle(Level world, BlockPos pos) {
-        for (int yy = 0; yy <= 2; yy++) {
-            for (int zz = 0; zz <= 2; zz++) {
-                for (int xx = 0; xx <= 2; xx++) {
+        for (int yy = 0; yy <= 2; yy++) 
+        {
+            for (int zz = 0; zz <= 2; zz++) 
+            {
+                for (int xx = 0; xx <= 2; xx++) 
+                {
                     Block b = StructurePattern[yy * 9 + zz * 3 + xx];
-                    if (b != null && b != Blocks.AIR && b != EnderRiftMod.RIFT.get()) {
+                    if (b != null && b != Blocks.AIR && b != EnderRiftMod.RIFT.get()) 
+                    {
                         BlockPos bp = pos.offset(xx - 1, yy - 1, zz - 1);
                         Block block = world.getBlockState(bp).getBlock();
                         if (block == EnderRiftMod.STRUCTURE_EDGE.get() || block == EnderRiftMod.STRUCTURE_CORNER.get())
@@ -208,7 +209,8 @@ public class RiftStructure {
 
         BlockState state = world.getBlockState(pos);
 
-        if (state.getBlock() == EnderRiftMod.RIFT.get() && state.getValue(RiftBlock.ASSEMBLED)) {
+        if (state.getBlock() == EnderRiftMod.RIFT.get() && state.getValue(RiftBlock.ASSEMBLED)) 
+        {
             world.setBlockAndUpdate(pos, state.setValue(RiftBlock.ASSEMBLED, false));
 
             RiftBlockEntity rift = (RiftBlockEntity) world.getBlockEntity(pos);
@@ -221,21 +223,29 @@ public class RiftStructure {
     }
 
     public static Block getOriginalBlock(BlockState state) {
-        if (state.getBlock() == EnderRiftMod.STRUCTURE_CORNER.get()) {
+        if (state.getBlock() == EnderRiftMod.STRUCTURE_CORNER.get()) 
+        {
             return StructurePattern[0];
-        } else if (state.getBlock() == EnderRiftMod.STRUCTURE_EDGE.get()) {
+        } else if (state.getBlock() == EnderRiftMod.STRUCTURE_EDGE.get()) 
+        {
             return StructurePattern[1];
-        } else {
+        } else 
+        {
             return StructurePattern[13];
         }
     }
 
-    public static Block getOriginalBlock(BlockGetter worldIn, BlockPos pos) {
-        for (int yy = 0; yy <= 2; yy++) {
-            for (int zz = 0; zz <= 2; zz++) {
-                for (int xx = 0; xx <= 2; xx++) {
+    public static Block getOriginalBlock(BlockGetter worldIn, BlockPos pos) 
+    {
+        for (int yy = 0; yy <= 2; yy++) 
+        {
+            for (int zz = 0; zz <= 2; zz++) 
+            {
+                for (int xx = 0; xx <= 2; xx++) 
+                {
                     BlockPos pos2 = pos.offset(1 - xx, 1 - yy, 1 - zz);
-                    if (worldIn.getBlockState(pos2).getBlock() == EnderRiftMod.RIFT.get()) {
+                    if (worldIn.getBlockState(pos2).getBlock() == EnderRiftMod.RIFT.get()) 
+                    {
                         return StructurePattern[yy * 9 + zz * 3 + xx];
                     }
                 }

--- a/src/main/java/dev/gigaherz/enderrift/rift/RiftStructure.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/RiftStructure.java
@@ -141,7 +141,8 @@ public class RiftStructure
                             BlockState st = world.getBlockState(bp);
                             if (!st.isAir())
                                 return false;
-                        } else if (b != EnderRiftMod.RIFT.get())
+                        } 
+                        else if (b != EnderRiftMod.RIFT.get())
                         {
                             if (b != w)
                                 return false;
@@ -232,10 +233,12 @@ public class RiftStructure
         if (state.getBlock() == EnderRiftMod.STRUCTURE_CORNER.get())
         {
             return StructurePattern[0];
-        } else if (state.getBlock() == EnderRiftMod.STRUCTURE_EDGE.get())
+        } 
+        else if (state.getBlock() == EnderRiftMod.STRUCTURE_EDGE.get())
         {
             return StructurePattern[1];
-        } else
+        } 
+        else
         {
             return StructurePattern[13];
         }

--- a/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftHolder.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftHolder.java
@@ -5,36 +5,36 @@ import java.util.UUID;
 public class RiftHolder
 {
 
-	private final UUID id;
-	private RiftInventory inventory;
+    private final UUID id;
+    private RiftInventory inventory;
 
-	RiftHolder(UUID id)
-	{
-		this.id = id;
-	}
+    RiftHolder(UUID id)
+    {
+        this.id = id;
+    }
 
-	public UUID getId()
-	{
-		return id;
-	}
+    public UUID getId()
+    {
+        return id;
+    }
 
-	public RiftInventory getInventory()
-	{
-		return inventory;
-	}
+    public RiftInventory getInventory()
+    {
+        return inventory;
+    }
 
-	public RiftInventory getInventoryOrCreate()
-	{
-		if (inventory != null)
-		{
-			return inventory;
-		}
-		return inventory = new RiftInventory(this);
-	}
+    public RiftInventory getInventoryOrCreate()
+    {
+        if (inventory != null)
+        {
+            return inventory;
+        }
+        return inventory = new RiftInventory(this);
+    }
 
-	public boolean isValid()
-	{
-		return inventory != null;
-	}
+    public boolean isValid()
+    {
+        return inventory != null;
+    }
 
 }

--- a/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftHolder.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftHolder.java
@@ -2,32 +2,39 @@ package dev.gigaherz.enderrift.rift.storage;
 
 import java.util.UUID;
 
-public class RiftHolder {
+public class RiftHolder
+{
 
-    private final UUID id;
-    private RiftInventory inventory;
+	private final UUID id;
+	private RiftInventory inventory;
 
-    RiftHolder(UUID id) {
-        this.id = id;
-    }
+	RiftHolder(UUID id)
+	{
+		this.id = id;
+	}
 
-    public UUID getId() {
-        return id;
-    }
+	public UUID getId()
+	{
+		return id;
+	}
 
-    public RiftInventory getInventory() {
-        return inventory;
-    }
+	public RiftInventory getInventory()
+	{
+		return inventory;
+	}
 
-    public RiftInventory getInventoryOrCreate() {
-        if (inventory != null) {
-            return inventory;
-        }
-        return inventory = new RiftInventory(this);
-    }
+	public RiftInventory getInventoryOrCreate()
+	{
+		if (inventory != null)
+		{
+			return inventory;
+		}
+		return inventory = new RiftInventory(this);
+	}
 
-    public boolean isValid() {
-        return inventory != null;
-    }
+	public boolean isValid()
+	{
+		return inventory != null;
+	}
 
 }

--- a/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftHolder.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftHolder.java
@@ -1,0 +1,46 @@
+package dev.gigaherz.enderrift.rift.storage;
+
+import java.util.UUID;
+
+public class RiftHolder {
+
+    private final UUID id;
+    private RiftInventory inventory;
+    private boolean dirty;
+
+    RiftHolder(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public RiftInventory getInventory() {
+        return inventory;
+    }
+
+    public RiftInventory getInventoryOrCreate() {
+        if (inventory != null) {
+            return inventory;
+        }
+        return inventory = new RiftInventory(this);
+    }
+
+    void resetDirty() {
+        dirty = false;
+    }
+
+    public boolean isDirty() {
+        return dirty;
+    }
+
+    public void setDirty() {
+        dirty = true;
+    }
+
+    public boolean isValid() {
+        return false;
+    }
+
+}

--- a/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftHolder.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftHolder.java
@@ -6,7 +6,6 @@ public class RiftHolder {
 
     private final UUID id;
     private RiftInventory inventory;
-    private boolean dirty;
 
     RiftHolder(UUID id) {
         this.id = id;
@@ -27,20 +26,8 @@ public class RiftHolder {
         return inventory = new RiftInventory(this);
     }
 
-    void resetDirty() {
-        dirty = false;
-    }
-
-    public boolean isDirty() {
-        return dirty;
-    }
-
-    public void setDirty() {
-        dirty = true;
-    }
-
     public boolean isValid() {
-        return false;
+        return inventory != null;
     }
 
 }

--- a/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftInventory.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftInventory.java
@@ -25,214 +25,214 @@ import net.minecraftforge.items.IItemHandler;
 public class RiftInventory implements IItemHandler
 {
 
-	final List<Reference<? extends IRiftChangeListener>> listeners = Lists.newArrayList();
-	final ReferenceQueue<IRiftChangeListener> pendingRemovals = new ReferenceQueue<>();
-	private final List<RiftSlot> slots = Lists.newArrayList();
-	private final RiftHolder holder;
+    final List<Reference<? extends IRiftChangeListener>> listeners = Lists.newArrayList();
+    final ReferenceQueue<IRiftChangeListener> pendingRemovals = new ReferenceQueue<>();
+    private final List<RiftSlot> slots = Lists.newArrayList();
+    private final RiftHolder holder;
 
-	RiftInventory(final RiftHolder holder)
-	{
-		this.holder = Objects.requireNonNull(holder);
-	}
+    RiftInventory(final RiftHolder holder)
+    {
+        this.holder = Objects.requireNonNull(holder);
+    }
 
-	public UUID getId()
-	{
-		return holder.getId();
-	}
+    public UUID getId()
+    {
+        return holder.getId();
+    }
 
-	public void addWeakListener(IRiftChangeListener e)
-	{
-		listeners.add(new WeakReference<>(e, pendingRemovals));
-	}
+    public void addWeakListener(IRiftChangeListener e)
+    {
+        listeners.add(new WeakReference<>(e, pendingRemovals));
+    }
 
-	private void walkListeners(Consumer<IRiftChangeListener> consumer)
-	{
-		for (Reference<? extends IRiftChangeListener> ref = pendingRemovals.poll(); ref != null; ref = pendingRemovals.poll())
-		{
-			listeners.remove(ref);
-		}
+    private void walkListeners(Consumer<IRiftChangeListener> consumer)
+    {
+        for (Reference<? extends IRiftChangeListener> ref = pendingRemovals.poll(); ref != null; ref = pendingRemovals.poll())
+        {
+            listeners.remove(ref);
+        }
 
-		for (Iterator<Reference<? extends IRiftChangeListener>> iterator = listeners.iterator(); iterator.hasNext();)
-		{
-			Reference<? extends IRiftChangeListener> reference = iterator.next();
-			IRiftChangeListener listener = reference.get();
-			if (listener == null || listener.isInvalid())
-			{
-				iterator.remove();
-				continue;
-			}
-			consumer.accept(listener);
-		}
-	}
+        for (Iterator<Reference<? extends IRiftChangeListener>> iterator = listeners.iterator(); iterator.hasNext();)
+        {
+            Reference<? extends IRiftChangeListener> reference = iterator.next();
+            IRiftChangeListener listener = reference.get();
+            if (listener == null || listener.isInvalid())
+            {
+                iterator.remove();
+                continue;
+            }
+            consumer.accept(listener);
+        }
+    }
 
-	protected void onContentsChanged()
-	{
-		walkListeners(IRiftChangeListener::onRiftChanged);
-	}
+    protected void onContentsChanged()
+    {
+        walkListeners(IRiftChangeListener::onRiftChanged);
+    }
 
-	public void locateListeners(Level level, Consumer<BlockPos> locationConsumer)
-	{
-		walkListeners(listener -> {
-			if (!level.dimension().equals(listener.getRiftLevel().map(Level::dimension).orElse(null)))
-			{
-				return;
-			}
-			listener.getLocation().ifPresent(locationConsumer);
-		});
-	}
+    public void locateListeners(Level level, Consumer<BlockPos> locationConsumer)
+    {
+        walkListeners(listener -> {
+            if (!level.dimension().equals(listener.getRiftLevel().map(Level::dimension).orElse(null)))
+            {
+                return;
+            }
+            listener.getLocation().ifPresent(locationConsumer);
+        });
+    }
 
-	public long getCount(int slot)
-	{
-		if (slot < 0 || slot >= slots.size())
-		{
-			return 0;
-		}
-		return slots.get(slot).getCount();
-	}
+    public long getCount(int slot)
+    {
+        if (slot < 0 || slot >= slots.size())
+        {
+            return 0;
+        }
+        return slots.get(slot).getCount();
+    }
 
-	CompoundTag save()
-	{
-		CompoundTag root = new CompoundTag();
-		ListTag list = new ListTag();
-		RiftSlot[] slots = this.slots.toArray(RiftSlot[]::new);
-		for (RiftSlot slot : slots)
-		{
-			CompoundTag tag = new CompoundTag();
-			tag.putLong("Count", slot.getCount());
-			tag.put("Item", slot.getSample().save(new CompoundTag()));
-			list.add(tag);
-		}
-		root.put("Contents", list);
-		return root;
-	}
+    CompoundTag save()
+    {
+        CompoundTag root = new CompoundTag();
+        ListTag list = new ListTag();
+        RiftSlot[] slots = this.slots.toArray(RiftSlot[]::new);
+        for (RiftSlot slot : slots)
+        {
+            CompoundTag tag = new CompoundTag();
+            tag.putLong("Count", slot.getCount());
+            tag.put("Item", slot.getSample().save(new CompoundTag()));
+            list.add(tag);
+        }
+        root.put("Contents", list);
+        return root;
+    }
 
-	void load(CompoundTag root)
-	{
-		slots.clear();
-		ListTag list = root.getList("Contents", Tag.TAG_COMPOUND);
-		for (Tag rawTag : list)
-		{
-			CompoundTag tag = (CompoundTag) rawTag;
-			long count = tag.getLong("Count");
-			ItemStack stack = ItemStack.of(tag.getCompound("Item"));
-			RiftSlot slot = new RiftSlot(stack);
-			slot.setCount(count);
-			slots.add(slot);
-		}
-		onContentsChanged();
-	}
+    void load(CompoundTag root)
+    {
+        slots.clear();
+        ListTag list = root.getList("Contents", Tag.TAG_COMPOUND);
+        for (Tag rawTag : list)
+        {
+            CompoundTag tag = (CompoundTag) rawTag;
+            long count = tag.getLong("Count");
+            ItemStack stack = ItemStack.of(tag.getCompound("Item"));
+            RiftSlot slot = new RiftSlot(stack);
+            slot.setCount(count);
+            slots.add(slot);
+        }
+        onContentsChanged();
+    }
 
-	@Override
-	public int getSlots()
-	{
-		return slots.size() + 1;
-	}
+    @Override
+    public int getSlots()
+    {
+        return slots.size() + 1;
+    }
 
-	@Override
-	public @NotNull ItemStack getStackInSlot(int index)
-	{
-		if (index >= slots.size())
-		{
-			return ItemStack.EMPTY;
-		}
-		RiftSlot slot = slots.get(index);
-		ItemStack stack = slot.getSample().copy();
-		stack.setCount((int) Math.min(Integer.MAX_VALUE, slot.getCount()));
-		return stack;
-	}
+    @Override
+    public @NotNull ItemStack getStackInSlot(int index)
+    {
+        if (index >= slots.size())
+        {
+            return ItemStack.EMPTY;
+        }
+        RiftSlot slot = slots.get(index);
+        ItemStack stack = slot.getSample().copy();
+        stack.setCount((int) Math.min(Integer.MAX_VALUE, slot.getCount()));
+        return stack;
+    }
 
-	@Override
-	public @NotNull ItemStack insertItem(int index, @NotNull ItemStack stack, boolean simulate)
-	{
-		if (simulate)
-		{
-			return ItemStack.EMPTY;
-		}
-		try
-		{
-			if (index < slots.size() && index >= 0 && add(index, stack))
-			{
-				return ItemStack.EMPTY;
-			}
-			for (int i = 0; i < slots.size(); i++)
-			{
-				if (index == i || !add(i, stack))
-				{
-					continue;
-				}
-				return ItemStack.EMPTY;
-			}
-			slots.add(new RiftSlot(stack));
-			return ItemStack.EMPTY;
-		} finally
-		{
-			onContentsChanged();
-		}
-	}
+    @Override
+    public @NotNull ItemStack insertItem(int index, @NotNull ItemStack stack, boolean simulate)
+    {
+        if (simulate)
+        {
+            return ItemStack.EMPTY;
+        }
+        try
+        {
+            if (index < slots.size() && index >= 0 && add(index, stack))
+            {
+                return ItemStack.EMPTY;
+            }
+            for (int i = 0; i < slots.size(); i++)
+            {
+                if (index == i || !add(i, stack))
+                {
+                    continue;
+                }
+                return ItemStack.EMPTY;
+            }
+            slots.add(new RiftSlot(stack));
+            return ItemStack.EMPTY;
+        } finally
+        {
+            onContentsChanged();
+        }
+    }
 
-	private boolean add(int index, ItemStack stack)
-	{
-		RiftSlot slot = slots.get(index);
-		ItemStack sample = slot.getSample();
-		if (ItemStack.isSame(sample, stack) && ItemStack.tagMatches(sample, stack))
-		{
-			slot.addCount(stack.getCount());
-			return true;
-		}
-		return false;
-	}
+    private boolean add(int index, ItemStack stack)
+    {
+        RiftSlot slot = slots.get(index);
+        ItemStack sample = slot.getSample();
+        if (ItemStack.isSame(sample, stack) && ItemStack.tagMatches(sample, stack))
+        {
+            slot.addCount(stack.getCount());
+            return true;
+        }
+        return false;
+    }
 
-	@Override
-	public @NotNull ItemStack extractItem(int index, int wanted, boolean simulate)
-	{
-		if (index >= slots.size())
-		{
-			return ItemStack.EMPTY;
-		}
-		RiftSlot slot = slots.get(index);
-		long count = slot.getCount();
-		if (simulate)
-		{
-			int amount = (int) Math.min(wanted, count);
-			ItemStack stack = slot.getSample().copy();
-			stack.setCount(amount);
-			return stack;
-		}
-		try
-		{
-			if (count <= wanted)
-			{
-				ItemStack stack = slot.getSample();
-				stack.setCount((int) count);
-				slots.remove(index);
-				return stack;
-			}
-			ItemStack stack = slot.getSample().copy();
-			stack.setCount(wanted);
-			slot.subtractCount(wanted);
-			return stack;
-		} finally
-		{
-			onContentsChanged();
-		}
-	}
+    @Override
+    public @NotNull ItemStack extractItem(int index, int wanted, boolean simulate)
+    {
+        if (index >= slots.size())
+        {
+            return ItemStack.EMPTY;
+        }
+        RiftSlot slot = slots.get(index);
+        long count = slot.getCount();
+        if (simulate)
+        {
+            int amount = (int) Math.min(wanted, count);
+            ItemStack stack = slot.getSample().copy();
+            stack.setCount(amount);
+            return stack;
+        }
+        try
+        {
+            if (count <= wanted)
+            {
+                ItemStack stack = slot.getSample();
+                stack.setCount((int) count);
+                slots.remove(index);
+                return stack;
+            }
+            ItemStack stack = slot.getSample().copy();
+            stack.setCount(wanted);
+            slot.subtractCount(wanted);
+            return stack;
+        } finally
+        {
+            onContentsChanged();
+        }
+    }
 
-	@Override
-	public int getSlotLimit(int index)
-	{
-		return Integer.MAX_VALUE;
-	}
+    @Override
+    public int getSlotLimit(int index)
+    {
+        return Integer.MAX_VALUE;
+    }
 
-	@Override
-	public boolean isItemValid(int slot, @NotNull ItemStack stack)
-	{
-		return !ItemStack.isSame(ItemStack.EMPTY, stack);
-	}
+    @Override
+    public boolean isItemValid(int slot, @NotNull ItemStack stack)
+    {
+        return !ItemStack.isSame(ItemStack.EMPTY, stack);
+    }
 
-	public void clear()
-	{
-		slots.clear();
-		onContentsChanged();
-	}
+    public void clear()
+    {
+        slots.clear();
+        onContentsChanged();
+    }
 
 }

--- a/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftInventory.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftInventory.java
@@ -10,10 +10,8 @@ import java.util.UUID;
 import java.util.function.Consumer;
 
 import org.jetbrains.annotations.NotNull;
-import org.slf4j.Logger;
 
 import com.google.common.collect.Lists;
-import com.mojang.logging.LogUtils;
 
 import dev.gigaherz.enderrift.rift.IRiftChangeListener;
 import net.minecraft.core.BlockPos;

--- a/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftInventory.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftInventory.java
@@ -1,57 +1,55 @@
 package dev.gigaherz.enderrift.rift.storage;
 
-import com.google.common.collect.Lists;
-import dev.gigaherz.enderrift.rift.IRiftChangeListener;
-import net.minecraft.nbt.Tag;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.ListTag;
-import net.minecraft.core.BlockPos;
-import net.minecraftforge.items.IItemHandler;
-import net.minecraftforge.items.ItemHandlerHelper;
-
-import javax.annotation.Nonnull;
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
 import java.util.function.Consumer;
 
-public class RiftInventory implements IItemHandler
-{
-    private final RiftStorage manager;
+import org.jetbrains.annotations.NotNull;
+
+import com.google.common.collect.Lists;
+
+import dev.gigaherz.enderrift.rift.IRiftChangeListener;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.items.IItemHandler;
+
+public class RiftInventory implements IItemHandler {
 
     final List<Reference<? extends IRiftChangeListener>> listeners = Lists.newArrayList();
     final ReferenceQueue<IRiftChangeListener> pendingRemovals = new ReferenceQueue<>();
-    private final List<ItemStack> inventorySlots = Lists.newArrayList();
+    private final List<RiftSlot> slots = Lists.newArrayList();
+    private final RiftHolder holder;
 
-    RiftInventory(RiftStorage manager)
-    {
-        this.manager = manager;
+    RiftInventory(final RiftHolder holder) {
+        this.holder = Objects.requireNonNull(holder);
     }
 
-    public void addWeakListener(IRiftChangeListener e)
-    {
+    public UUID getId() {
+        return holder.getId();
+    }
+
+    public void addWeakListener(IRiftChangeListener e) {
         listeners.add(new WeakReference<>(e, pendingRemovals));
     }
 
-    private void walkListeners(Consumer<IRiftChangeListener> consumer)
-    {
-        for (Reference<? extends IRiftChangeListener>
-             ref = pendingRemovals.poll();
-             ref != null;
-             ref = pendingRemovals.poll())
-        {
+    private void walkListeners(Consumer<IRiftChangeListener> consumer) {
+        for (Reference<? extends IRiftChangeListener> ref = pendingRemovals.poll(); ref != null; ref = pendingRemovals.poll()) {
             listeners.remove(ref);
         }
 
-        for (Iterator<Reference<? extends IRiftChangeListener>> iterator = listeners.iterator(); iterator.hasNext(); )
-        {
+        for (Iterator<Reference<? extends IRiftChangeListener>> iterator = listeners.iterator(); iterator.hasNext();) {
             Reference<? extends IRiftChangeListener> reference = iterator.next();
             IRiftChangeListener listener = reference.get();
-            if (listener == null || listener.isInvalid())
-            {
+            if (listener == null || listener.isInvalid()) {
                 iterator.remove();
                 continue;
             }
@@ -59,140 +57,142 @@ public class RiftInventory implements IItemHandler
         }
     }
 
-    protected void onContentsChanged()
-    {
+    protected void onContentsChanged() {
         walkListeners(IRiftChangeListener::onRiftChanged);
-        manager.setDirty();
+        holder.setDirty();
     }
 
-    public void locateListeners(Consumer<BlockPos> locationConsumer)
-    {
-        walkListeners(listener -> listener.getLocation().ifPresent(locationConsumer));
-    }
-
-    public void readFromNBT(CompoundTag nbtTagCompound)
-    {
-        ListTag itemList = nbtTagCompound.getList("Items", Tag.TAG_COMPOUND);
-
-        inventorySlots.clear();
-
-        for (int i = 0; i < itemList.size(); ++i)
-        {
-            CompoundTag slot = itemList.getCompound(i);
-            inventorySlots.add(ItemStack.of(slot));
-        }
-    }
-
-    public void writeToNBT(CompoundTag nbtTagCompound)
-    {
-        ListTag itemList = new ListTag();
-
-        for (ItemStack stack : inventorySlots)
-        {
-            if (stack != null)
-            {
-                CompoundTag slot = new CompoundTag();
-                stack.save(slot);
-                itemList.add(slot);
+    public void locateListeners(Level level, Consumer<BlockPos> locationConsumer) {
+        walkListeners(listener -> {
+            if (!level.dimension().equals(listener.getRiftLevel().map(Level::dimension).orElse(null))) {
+                return;
             }
+            listener.getLocation().ifPresent(locationConsumer);
+        });
+    }
+
+    CompoundTag save() {
+        CompoundTag root = new CompoundTag();
+        ListTag list = new ListTag();
+        RiftSlot[] slots = this.slots.toArray(RiftSlot[]::new);
+        for (RiftSlot slot : slots) {
+            CompoundTag tag = new CompoundTag();
+            tag.putLong("Count", slot.getCount());
+            tag.put("Item", slot.getSample().save(new CompoundTag()));
+            list.add(tag);
         }
+        root.put("Contents", list);
+        return root;
+    }
 
-        nbtTagCompound.put("Items", itemList);
+    void load(CompoundTag root) {
+        slots.clear();
+        ListTag list = root.getList("Contents", Tag.TAG_COMPOUND);
+        for (Tag rawTag : list) {
+            CompoundTag tag = (CompoundTag) rawTag;
+            long count = tag.getLong("Count");
+            ItemStack stack = ItemStack.of(tag.getCompound("Item"));
+            RiftSlot slot = new RiftSlot(stack);
+            slot.setCount(count);
+            slots.add(slot);
+        }
+        onContentsChanged();
     }
 
     @Override
-    public int getSlots()
-    {
-        return inventorySlots.size() + 1;
+    public int getSlots() {
+        return slots.size() + 1;
     }
 
     @Override
-    public ItemStack getStackInSlot(int index)
-    {
-        if (index >= inventorySlots.size())
+    public @NotNull ItemStack getStackInSlot(int index) {
+        if (index >= slots.size()) {
             return ItemStack.EMPTY;
-        return inventorySlots.get(index);
+        }
+        RiftSlot slot = slots.get(index);
+        ItemStack stack = slot.getSample().copy();
+        if (slot.getCount() > stack.getMaxStackSize()) {
+            stack.setCount(stack.getMaxStackSize());
+        } else {
+            stack.setCount((int) slot.getCount());
+        }
+        return stack;
     }
 
     @Override
-    public ItemStack insertItem(int index, ItemStack stack, boolean simulate)
-    {
-        if (index >= inventorySlots.size())
-        {
-            if (!simulate)
-            {
-                inventorySlots.add(stack.copy());
-                onContentsChanged();
+    public @NotNull ItemStack insertItem(int index, @NotNull ItemStack stack, boolean simulate) {
+        if (simulate) {
+            return ItemStack.EMPTY;
+        }
+        try {
+            if (index < slots.size() && index >= 0 && add(index, stack)) {
+                return ItemStack.EMPTY;
             }
-            return ItemStack.EMPTY;
-        }
-
-        ItemStack remaining = stack.copy();
-        ItemStack slot = inventorySlots.get(index);
-        if (slot.getCount() > 0)
-        {
-            int max = Math.min(remaining.getMaxStackSize(), 64);
-            int transfer = Math.min(remaining.getCount(), max - slot.getCount());
-            if (transfer > 0 && ItemHandlerHelper.canItemStacksStack(remaining, slot))
-            {
-                if (!simulate) slot.grow(transfer);
-                remaining.shrink(transfer);
-                if (remaining.getCount() <= 0)
-                    remaining = ItemStack.EMPTY;
+            for (int i = 0; i < slots.size(); i++) {
+                if (index == i || !add(i, stack)) {
+                    continue;
+                }
+                return ItemStack.EMPTY;
             }
+            slots.add(new RiftSlot(stack));
+            return ItemStack.EMPTY;
+        } finally {
+            onContentsChanged();
         }
+    }
 
-        if (!simulate) onContentsChanged();
-
-        return remaining;
+    private boolean add(int index, ItemStack stack) {
+        RiftSlot slot = slots.get(index);
+        ItemStack sample = slot.getSample();
+        if (ItemStack.isSame(sample, stack) && ItemStack.tagMatches(sample, stack)) {
+            slot.addCount(stack.getCount());
+            return true;
+        }
+        return false;
     }
 
     @Override
-    public ItemStack extractItem(int index, int wanted, boolean simulate)
-    {
-        if (index >= inventorySlots.size())
-        {
+    public @NotNull ItemStack extractItem(int index, int wanted, boolean simulate) {
+        if (index >= slots.size()) {
             return ItemStack.EMPTY;
         }
-
-        ItemStack slot = inventorySlots.get(index);
-        if (slot == null)
-            return ItemStack.EMPTY;
-
-        ItemStack _extracted = slot.copy();
-        int extractedCount = 0;
-
-        int available = Math.min(wanted, slot.getCount());
-        if (available > 0)
-        {
-            extractedCount += available;
-
-            if (!simulate)
-            {
-                slot.shrink(available);
-                if (slot.getCount() <= 0)
-                    inventorySlots.remove(index);
+        RiftSlot slot = slots.get(index);
+        long count = slot.getCount();
+        if (simulate) {
+            int amount = (int) Math.min(wanted, count);
+            ItemStack stack = slot.getSample().copy();
+            stack.setCount(amount);
+            return stack;
+        }
+        try {
+            if (count <= wanted) {
+                ItemStack stack = slot.getSample();
+                stack.setCount((int) count);
+                slots.remove(index);
+                return stack;
             }
+            ItemStack stack = slot.getSample().copy();
+            stack.setCount(wanted);
+            slot.subtractCount(wanted);
+            return stack;
+        } finally {
+            onContentsChanged();
         }
-
-        if (extractedCount <= 0)
-            return ItemStack.EMPTY;
-
-        if (!simulate) onContentsChanged();
-
-        _extracted.setCount(extractedCount);
-        return _extracted;
     }
 
     @Override
-    public int getSlotLimit(int slot)
-    {
-        return 64;
+    public int getSlotLimit(int index) {
+        return Integer.MAX_VALUE;
     }
 
     @Override
-    public boolean isItemValid(int slot, @Nonnull ItemStack stack)
-    {
+    public boolean isItemValid(int slot, @NotNull ItemStack stack) {
         return true;
     }
+
+    public void clear() {
+        slots.clear();
+        onContentsChanged();
+    }
+
 }

--- a/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftInventory.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftInventory.java
@@ -22,179 +22,217 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.items.IItemHandler;
 
-public class RiftInventory implements IItemHandler {
+public class RiftInventory implements IItemHandler
+{
 
-    final List<Reference<? extends IRiftChangeListener>> listeners = Lists.newArrayList();
-    final ReferenceQueue<IRiftChangeListener> pendingRemovals = new ReferenceQueue<>();
-    private final List<RiftSlot> slots = Lists.newArrayList();
-    private final RiftHolder holder;
+	final List<Reference<? extends IRiftChangeListener>> listeners = Lists.newArrayList();
+	final ReferenceQueue<IRiftChangeListener> pendingRemovals = new ReferenceQueue<>();
+	private final List<RiftSlot> slots = Lists.newArrayList();
+	private final RiftHolder holder;
 
-    RiftInventory(final RiftHolder holder) {
-        this.holder = Objects.requireNonNull(holder);
-    }
+	RiftInventory(final RiftHolder holder)
+	{
+		this.holder = Objects.requireNonNull(holder);
+	}
 
-    public UUID getId() {
-        return holder.getId();
-    }
+	public UUID getId()
+	{
+		return holder.getId();
+	}
 
-    public void addWeakListener(IRiftChangeListener e) {
-        listeners.add(new WeakReference<>(e, pendingRemovals));
-    }
+	public void addWeakListener(IRiftChangeListener e)
+	{
+		listeners.add(new WeakReference<>(e, pendingRemovals));
+	}
 
-    private void walkListeners(Consumer<IRiftChangeListener> consumer) {
-        for (Reference<? extends IRiftChangeListener> ref = pendingRemovals.poll(); ref != null; ref = pendingRemovals.poll()) {
-            listeners.remove(ref);
-        }
+	private void walkListeners(Consumer<IRiftChangeListener> consumer)
+	{
+		for (Reference<? extends IRiftChangeListener> ref = pendingRemovals.poll(); ref != null; ref = pendingRemovals.poll())
+		{
+			listeners.remove(ref);
+		}
 
-        for (Iterator<Reference<? extends IRiftChangeListener>> iterator = listeners.iterator(); iterator.hasNext();) {
-            Reference<? extends IRiftChangeListener> reference = iterator.next();
-            IRiftChangeListener listener = reference.get();
-            if (listener == null || listener.isInvalid()) {
-                iterator.remove();
-                continue;
-            }
-            consumer.accept(listener);
-        }
-    }
+		for (Iterator<Reference<? extends IRiftChangeListener>> iterator = listeners.iterator(); iterator.hasNext();)
+		{
+			Reference<? extends IRiftChangeListener> reference = iterator.next();
+			IRiftChangeListener listener = reference.get();
+			if (listener == null || listener.isInvalid())
+			{
+				iterator.remove();
+				continue;
+			}
+			consumer.accept(listener);
+		}
+	}
 
-    protected void onContentsChanged() {
-        walkListeners(IRiftChangeListener::onRiftChanged);
-    }
+	protected void onContentsChanged()
+	{
+		walkListeners(IRiftChangeListener::onRiftChanged);
+	}
 
-    public void locateListeners(Level level, Consumer<BlockPos> locationConsumer) {
-        walkListeners(listener -> {
-            if (!level.dimension().equals(listener.getRiftLevel().map(Level::dimension).orElse(null))) {
-                return;
-            }
-            listener.getLocation().ifPresent(locationConsumer);
-        });
-    }
+	public void locateListeners(Level level, Consumer<BlockPos> locationConsumer)
+	{
+		walkListeners(listener -> {
+			if (!level.dimension().equals(listener.getRiftLevel().map(Level::dimension).orElse(null)))
+			{
+				return;
+			}
+			listener.getLocation().ifPresent(locationConsumer);
+		});
+	}
 
-    public long getCount(int slot) {
-        if (slot < 0 || slot >= slots.size()) {
-            return 0;
-        }
-        return slots.get(slot).getCount();
-    }
+	public long getCount(int slot)
+	{
+		if (slot < 0 || slot >= slots.size())
+		{
+			return 0;
+		}
+		return slots.get(slot).getCount();
+	}
 
-    CompoundTag save() {
-        CompoundTag root = new CompoundTag();
-        ListTag list = new ListTag();
-        RiftSlot[] slots = this.slots.toArray(RiftSlot[]::new);
-        for (RiftSlot slot : slots) {
-            CompoundTag tag = new CompoundTag();
-            tag.putLong("Count", slot.getCount());
-            tag.put("Item", slot.getSample().save(new CompoundTag()));
-            list.add(tag);
-        }
-        root.put("Contents", list);
-        return root;
-    }
+	CompoundTag save()
+	{
+		CompoundTag root = new CompoundTag();
+		ListTag list = new ListTag();
+		RiftSlot[] slots = this.slots.toArray(RiftSlot[]::new);
+		for (RiftSlot slot : slots)
+		{
+			CompoundTag tag = new CompoundTag();
+			tag.putLong("Count", slot.getCount());
+			tag.put("Item", slot.getSample().save(new CompoundTag()));
+			list.add(tag);
+		}
+		root.put("Contents", list);
+		return root;
+	}
 
-    void load(CompoundTag root) {
-        slots.clear();
-        ListTag list = root.getList("Contents", Tag.TAG_COMPOUND);
-        for (Tag rawTag : list) {
-            CompoundTag tag = (CompoundTag) rawTag;
-            long count = tag.getLong("Count");
-            ItemStack stack = ItemStack.of(tag.getCompound("Item"));
-            RiftSlot slot = new RiftSlot(stack);
-            slot.setCount(count);
-            slots.add(slot);
-        }
-        onContentsChanged();
-    }
+	void load(CompoundTag root)
+	{
+		slots.clear();
+		ListTag list = root.getList("Contents", Tag.TAG_COMPOUND);
+		for (Tag rawTag : list)
+		{
+			CompoundTag tag = (CompoundTag) rawTag;
+			long count = tag.getLong("Count");
+			ItemStack stack = ItemStack.of(tag.getCompound("Item"));
+			RiftSlot slot = new RiftSlot(stack);
+			slot.setCount(count);
+			slots.add(slot);
+		}
+		onContentsChanged();
+	}
 
-    @Override
-    public int getSlots() {
-        return slots.size() + 1;
-    }
+	@Override
+	public int getSlots()
+	{
+		return slots.size() + 1;
+	}
 
-    @Override
-    public @NotNull ItemStack getStackInSlot(int index) {
-        if (index >= slots.size()) {
-            return ItemStack.EMPTY;
-        }
-        RiftSlot slot = slots.get(index);
-        ItemStack stack = slot.getSample().copy();
-        stack.setCount((int) Math.min(Integer.MAX_VALUE, slot.getCount()));
-        return stack;
-    }
+	@Override
+	public @NotNull ItemStack getStackInSlot(int index)
+	{
+		if (index >= slots.size())
+		{
+			return ItemStack.EMPTY;
+		}
+		RiftSlot slot = slots.get(index);
+		ItemStack stack = slot.getSample().copy();
+		stack.setCount((int) Math.min(Integer.MAX_VALUE, slot.getCount()));
+		return stack;
+	}
 
-    @Override
-    public @NotNull ItemStack insertItem(int index, @NotNull ItemStack stack, boolean simulate) {
-        if (simulate) {
-            return ItemStack.EMPTY;
-        }
-        try {
-            if (index < slots.size() && index >= 0 && add(index, stack)) {
-                return ItemStack.EMPTY;
-            }
-            for (int i = 0; i < slots.size(); i++) {
-                if (index == i || !add(i, stack)) {
-                    continue;
-                }
-                return ItemStack.EMPTY;
-            }
-            slots.add(new RiftSlot(stack));
-            return ItemStack.EMPTY;
-        } finally {
-            onContentsChanged();
-        }
-    }
+	@Override
+	public @NotNull ItemStack insertItem(int index, @NotNull ItemStack stack, boolean simulate)
+	{
+		if (simulate)
+		{
+			return ItemStack.EMPTY;
+		}
+		try
+		{
+			if (index < slots.size() && index >= 0 && add(index, stack))
+			{
+				return ItemStack.EMPTY;
+			}
+			for (int i = 0; i < slots.size(); i++)
+			{
+				if (index == i || !add(i, stack))
+				{
+					continue;
+				}
+				return ItemStack.EMPTY;
+			}
+			slots.add(new RiftSlot(stack));
+			return ItemStack.EMPTY;
+		} finally
+		{
+			onContentsChanged();
+		}
+	}
 
-    private boolean add(int index, ItemStack stack) {
-        RiftSlot slot = slots.get(index);
-        ItemStack sample = slot.getSample();
-        if (ItemStack.isSame(sample, stack) && ItemStack.tagMatches(sample, stack)) {
-            slot.addCount(stack.getCount());
-            return true;
-        }
-        return false;
-    }
+	private boolean add(int index, ItemStack stack)
+	{
+		RiftSlot slot = slots.get(index);
+		ItemStack sample = slot.getSample();
+		if (ItemStack.isSame(sample, stack) && ItemStack.tagMatches(sample, stack))
+		{
+			slot.addCount(stack.getCount());
+			return true;
+		}
+		return false;
+	}
 
-    @Override
-    public @NotNull ItemStack extractItem(int index, int wanted, boolean simulate) {
-        if (index >= slots.size()) {
-            return ItemStack.EMPTY;
-        }
-        RiftSlot slot = slots.get(index);
-        long count = slot.getCount();
-        if (simulate) {
-            int amount = (int) Math.min(wanted, count);
-            ItemStack stack = slot.getSample().copy();
-            stack.setCount(amount);
-            return stack;
-        }
-        try {
-            if (count <= wanted) {
-                ItemStack stack = slot.getSample();
-                stack.setCount((int) count);
-                slots.remove(index);
-                return stack;
-            }
-            ItemStack stack = slot.getSample().copy();
-            stack.setCount(wanted);
-            slot.subtractCount(wanted);
-            return stack;
-        } finally {
-            onContentsChanged();
-        }
-    }
+	@Override
+	public @NotNull ItemStack extractItem(int index, int wanted, boolean simulate)
+	{
+		if (index >= slots.size())
+		{
+			return ItemStack.EMPTY;
+		}
+		RiftSlot slot = slots.get(index);
+		long count = slot.getCount();
+		if (simulate)
+		{
+			int amount = (int) Math.min(wanted, count);
+			ItemStack stack = slot.getSample().copy();
+			stack.setCount(amount);
+			return stack;
+		}
+		try
+		{
+			if (count <= wanted)
+			{
+				ItemStack stack = slot.getSample();
+				stack.setCount((int) count);
+				slots.remove(index);
+				return stack;
+			}
+			ItemStack stack = slot.getSample().copy();
+			stack.setCount(wanted);
+			slot.subtractCount(wanted);
+			return stack;
+		} finally
+		{
+			onContentsChanged();
+		}
+	}
 
-    @Override
-    public int getSlotLimit(int index) {
-        return Integer.MAX_VALUE;
-    }
+	@Override
+	public int getSlotLimit(int index)
+	{
+		return Integer.MAX_VALUE;
+	}
 
-    @Override
-    public boolean isItemValid(int slot, @NotNull ItemStack stack) {
-        return !ItemStack.isSame(ItemStack.EMPTY, stack);
-    }
+	@Override
+	public boolean isItemValid(int slot, @NotNull ItemStack stack)
+	{
+		return !ItemStack.isSame(ItemStack.EMPTY, stack);
+	}
 
-    public void clear() {
-        slots.clear();
-        onContentsChanged();
-    }
+	public void clear()
+	{
+		slots.clear();
+		onContentsChanged();
+	}
 
 }

--- a/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftMigration.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftMigration.java
@@ -1,11 +1,12 @@
 package dev.gigaherz.enderrift.rift.storage;
 
-public abstract class RiftMigration {
-    
-    protected abstract boolean isApplicable(RiftStorage storage);
-    
-    protected abstract void migrate(RiftStorage storage) throws Exception;
+public abstract class RiftMigration
+{
 
-    protected abstract String getName();
+	protected abstract boolean isApplicable(RiftStorage storage);
+
+	protected abstract void migrate(RiftStorage storage) throws Exception;
+
+	protected abstract String getName();
 
 }

--- a/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftMigration.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftMigration.java
@@ -3,10 +3,10 @@ package dev.gigaherz.enderrift.rift.storage;
 public abstract class RiftMigration
 {
 
-	protected abstract boolean isApplicable(RiftStorage storage);
+    protected abstract boolean isApplicable(RiftStorage storage);
 
-	protected abstract void migrate(RiftStorage storage) throws Exception;
+    protected abstract void migrate(RiftStorage storage) throws Exception;
 
-	protected abstract String getName();
+    protected abstract String getName();
 
 }

--- a/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftMigration.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftMigration.java
@@ -1,0 +1,11 @@
+package dev.gigaherz.enderrift.rift.storage;
+
+public abstract class RiftMigration {
+    
+    protected abstract boolean isApplicable(RiftStorage storage);
+    
+    protected abstract void migrate(RiftStorage storage) throws Exception;
+
+    protected abstract String getName();
+
+}

--- a/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftSlot.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftSlot.java
@@ -1,0 +1,42 @@
+package dev.gigaherz.enderrift.rift.storage;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.item.ItemStack;
+
+public class RiftSlot {
+
+    private final ItemStack sample;
+    private long count;
+
+    public RiftSlot(ItemStack stack) {
+        this.sample = stack.copy();
+        sample.setCount(1);
+        this.count = stack.getCount();
+    }
+
+    public RiftSlot(CompoundTag tag) {
+        this.count = tag.getLong("Count");
+        this.sample = ItemStack.of(tag.getCompound("Item"));
+    }
+
+    public ItemStack getSample() {
+        return sample;
+    }
+
+    public long getCount() {
+        return count;
+    }
+    
+    public void addCount(long count) {
+        this.count += count;
+    }
+    
+    public void subtractCount(long count) {
+        this.count -= count;
+    }
+
+    public void setCount(long count) {
+        this.count = count;
+    }
+
+}

--- a/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftSlot.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftSlot.java
@@ -3,40 +3,48 @@ package dev.gigaherz.enderrift.rift.storage;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.item.ItemStack;
 
-public class RiftSlot {
+public class RiftSlot
+{
 
-    private final ItemStack sample;
-    private long count;
+	private final ItemStack sample;
+	private long count;
 
-    public RiftSlot(ItemStack stack) {
-        this.sample = stack.copy();
-        sample.setCount(1);
-        this.count = stack.getCount();
-    }
+	public RiftSlot(ItemStack stack)
+	{
+		this.sample = stack.copy();
+		sample.setCount(1);
+		this.count = stack.getCount();
+	}
 
-    public RiftSlot(CompoundTag tag) {
-        this.count = tag.getLong("Count");
-        this.sample = ItemStack.of(tag.getCompound("Item"));
-    }
+	public RiftSlot(CompoundTag tag)
+	{
+		this.count = tag.getLong("Count");
+		this.sample = ItemStack.of(tag.getCompound("Item"));
+	}
 
-    public ItemStack getSample() {
-        return sample;
-    }
+	public ItemStack getSample()
+	{
+		return sample;
+	}
 
-    public long getCount() {
-        return count;
-    }
-    
-    public void addCount(long count) {
-        this.count += count;
-    }
-    
-    public void subtractCount(long count) {
-        this.count -= count;
-    }
+	public long getCount()
+	{
+		return count;
+	}
 
-    public void setCount(long count) {
-        this.count = count;
-    }
+	public void addCount(long count)
+	{
+		this.count += count;
+	}
+
+	public void subtractCount(long count)
+	{
+		this.count -= count;
+	}
+
+	public void setCount(long count)
+	{
+		this.count = count;
+	}
 
 }

--- a/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftSlot.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftSlot.java
@@ -6,45 +6,45 @@ import net.minecraft.world.item.ItemStack;
 public class RiftSlot
 {
 
-	private final ItemStack sample;
-	private long count;
+    private final ItemStack sample;
+    private long count;
 
-	public RiftSlot(ItemStack stack)
-	{
-		this.sample = stack.copy();
-		sample.setCount(1);
-		this.count = stack.getCount();
-	}
+    public RiftSlot(ItemStack stack)
+    {
+        this.sample = stack.copy();
+        sample.setCount(1);
+        this.count = stack.getCount();
+    }
 
-	public RiftSlot(CompoundTag tag)
-	{
-		this.count = tag.getLong("Count");
-		this.sample = ItemStack.of(tag.getCompound("Item"));
-	}
+    public RiftSlot(CompoundTag tag)
+    {
+        this.count = tag.getLong("Count");
+        this.sample = ItemStack.of(tag.getCompound("Item"));
+    }
 
-	public ItemStack getSample()
-	{
-		return sample;
-	}
+    public ItemStack getSample()
+    {
+        return sample;
+    }
 
-	public long getCount()
-	{
-		return count;
-	}
+    public long getCount()
+    {
+        return count;
+    }
 
-	public void addCount(long count)
-	{
-		this.count += count;
-	}
+    public void addCount(long count)
+    {
+        this.count += count;
+    }
 
-	public void subtractCount(long count)
-	{
-		this.count -= count;
-	}
+    public void subtractCount(long count)
+    {
+        this.count -= count;
+    }
 
-	public void setCount(long count)
-	{
-		this.count = count;
-	}
+    public void setCount(long count)
+    {
+        this.count = count;
+    }
 
 }

--- a/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftStorage.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftStorage.java
@@ -25,285 +25,285 @@ import net.minecraft.world.level.storage.LevelResource;
 public class RiftStorage implements FilenameFilter
 {
 
-	public static final LevelResource DATA_DIR = new LevelResource("enderrift");
-	public static final String FILE_FORMAT = ".dat";
-	public static final int FILE_FORMAT_LENGTH = FILE_FORMAT.length();
+    public static final LevelResource DATA_DIR = new LevelResource("enderrift");
+    public static final String FILE_FORMAT = ".dat";
+    public static final int FILE_FORMAT_LENGTH = FILE_FORMAT.length();
 
-	private static final Logger LOGGER = LogUtils.getLogger();
-	private static final Function<UUID, RiftHolder> BUILDER = RiftHolder::new;
+    private static final Logger LOGGER = LogUtils.getLogger();
+    private static final Function<UUID, RiftHolder> BUILDER = RiftHolder::new;
 
-	@SuppressWarnings("unchecked")
-	private static final Class<? extends RiftMigration>[] MIGRATIONS = new Class[]
-	{ RiftMigration_17_08_2022.class };
+    @SuppressWarnings("unchecked")
+    private static final Class<? extends RiftMigration>[] MIGRATIONS = new Class[]
+    { RiftMigration_17_08_2022.class };
 
-	private static RiftStorage STORAGE;
+    private static RiftStorage STORAGE;
 
-	public static RiftStorage get()
-	{
-		return STORAGE;
-	}
+    public static RiftStorage get()
+    {
+        return STORAGE;
+    }
 
-	public static boolean isAvailable()
-	{
-		return STORAGE != null;
-	}
+    public static boolean isAvailable()
+    {
+        return STORAGE != null;
+    }
 
-	public static void init(MinecraftServer server)
-	{
-		if (STORAGE != null)
-		{
-			return;
-		}
-		STORAGE = new RiftStorage(server);
-		STORAGE.migrate();
-		STORAGE.loadAll();
-	}
+    public static void init(MinecraftServer server)
+    {
+        if (STORAGE != null)
+        {
+            return;
+        }
+        STORAGE = new RiftStorage(server);
+        STORAGE.migrate();
+        STORAGE.loadAll();
+    }
 
-	public static void deinit()
-	{
-		if (STORAGE == null)
-		{
-			return;
-		}
-		STORAGE.saveAll();
-		STORAGE = null;
-	}
+    public static void deinit()
+    {
+        if (STORAGE == null)
+        {
+            return;
+        }
+        STORAGE.saveAll();
+        STORAGE = null;
+    }
 
-	private final HashMap<UUID, RiftHolder> rifts = new HashMap<>();
-	private final Map<Class<? extends RiftMigration>, RiftMigration> migrations;
-	// ReadLock => Access to the rift data
-	// WriteLock => Modification of rift data
-	private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
-	private final File dataDirectory;
+    private final HashMap<UUID, RiftHolder> rifts = new HashMap<>();
+    private final Map<Class<? extends RiftMigration>, RiftMigration> migrations;
+    // ReadLock => Access to the rift data
+    // WriteLock => Modification of rift data
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+    private final File dataDirectory;
 
-	private RiftStorage(MinecraftServer server)
-	{
-		this.dataDirectory = server.getWorldPath(DATA_DIR).toFile();
-		Map<Class<? extends RiftMigration>, RiftMigration> migrations = new HashMap<>();
-		for (Class<? extends RiftMigration> migration : MIGRATIONS)
-		{
-			if (migration == null)
-			{
-				continue;
-			}
-			try
-			{
-				migrations.put(migration, migration.cast(migration.getConstructor().newInstance()));
-			} catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException | SecurityException e)
-			{
-				LOGGER.warn("Failed to load migration '{}'", migration.getSimpleName());
-				continue;
-			}
-		}
-		this.migrations = Collections.unmodifiableMap(migrations);
-	}
+    private RiftStorage(MinecraftServer server)
+    {
+        this.dataDirectory = server.getWorldPath(DATA_DIR).toFile();
+        Map<Class<? extends RiftMigration>, RiftMigration> migrations = new HashMap<>();
+        for (Class<? extends RiftMigration> migration : MIGRATIONS)
+        {
+            if (migration == null)
+            {
+                continue;
+            }
+            try
+            {
+                migrations.put(migration, migration.cast(migration.getConstructor().newInstance()));
+            } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException | SecurityException e)
+            {
+                LOGGER.warn("Failed to load migration '{}'", migration.getSimpleName());
+                continue;
+            }
+        }
+        this.migrations = Collections.unmodifiableMap(migrations);
+    }
 
-	public <E extends RiftMigration> E getMigration(Class<E> type)
-	{
-		RiftMigration migration = migrations.get(type);
-		if (migration == null)
-		{
-			return null;
-		}
-		return type.cast(migration);
-	}
+    public <E extends RiftMigration> E getMigration(Class<E> type)
+    {
+        RiftMigration migration = migrations.get(type);
+        if (migration == null)
+        {
+            return null;
+        }
+        return type.cast(migration);
+    }
 
-	private void migrate()
-	{
-		for (RiftMigration migration : migrations.values())
-		{
-			if (!migration.isApplicable(this))
-			{
-				continue;
-			}
-			LOGGER.info("Running migration '{}'", migration.getName());
-			try
-			{
-				migration.migrate(this);
-			} catch (Exception exp)
-			{
-				LOGGER.warn("Failed to run migration '{}'", migration.getName(), exp);
-			}
-		}
-	}
+    private void migrate()
+    {
+        for (RiftMigration migration : migrations.values())
+        {
+            if (!migration.isApplicable(this))
+            {
+                continue;
+            }
+            LOGGER.info("Running migration '{}'", migration.getName());
+            try
+            {
+                migration.migrate(this);
+            } catch (Exception exp)
+            {
+                LOGGER.warn("Failed to run migration '{}'", migration.getName(), exp);
+            }
+        }
+    }
 
-	public File getDataDirectory()
-	{
-		return dataDirectory;
-	}
+    public File getDataDirectory()
+    {
+        return dataDirectory;
+    }
 
-	public RiftHolder newRift()
-	{
-		UUID id;
-		lock.readLock().lock();
-		try
-		{
-			while (rifts.containsKey(id = UUID.randomUUID()))
-			{
-			}
-			return rifts.computeIfAbsent(id, BUILDER);
-		} finally
-		{
-			lock.readLock().unlock();
-		}
-	}
+    public RiftHolder newRift()
+    {
+        UUID id;
+        lock.readLock().lock();
+        try
+        {
+            while (rifts.containsKey(id = UUID.randomUUID()))
+            {
+            }
+            return rifts.computeIfAbsent(id, BUILDER);
+        } finally
+        {
+            lock.readLock().unlock();
+        }
+    }
 
-	public RiftHolder getRift(UUID id)
-	{
-		if (id == null)
-		{
-			return null;
-		}
-		lock.readLock().lock();
-		try
-		{
-			return rifts.computeIfAbsent(id, BUILDER);
-		} finally
-		{
-			lock.readLock().unlock();
-		}
-	}
+    public RiftHolder getRift(UUID id)
+    {
+        if (id == null)
+        {
+            return null;
+        }
+        lock.readLock().lock();
+        try
+        {
+            return rifts.computeIfAbsent(id, BUILDER);
+        } finally
+        {
+            lock.readLock().unlock();
+        }
+    }
 
-	public void loadAll()
-	{
-		// Prevent others from reading the map before every Rift is fully loaded
-		lock.writeLock().lock();
-		try
-		{
-			if (!dataDirectory.exists())
-			{
-				return;
-			}
-			File[] files = dataDirectory.listFiles(this);
-			for (File file : files)
-			{
-				String name = file.getName();
-				name = name.substring(0, name.length() - FILE_FORMAT_LENGTH);
-				UUID id;
-				try
-				{
-					id = UUID.fromString(name);
-				} catch (IllegalArgumentException iae)
-				{
-					LOGGER.warn("Found invalid rift name {}", name, iae);
-					continue;
-				}
-				load(id, file);
-			}
-		} finally
-		{
-			lock.writeLock().unlock();
-		}
-	}
+    public void loadAll()
+    {
+        // Prevent others from reading the map before every Rift is fully loaded
+        lock.writeLock().lock();
+        try
+        {
+            if (!dataDirectory.exists())
+            {
+                return;
+            }
+            File[] files = dataDirectory.listFiles(this);
+            for (File file : files)
+            {
+                String name = file.getName();
+                name = name.substring(0, name.length() - FILE_FORMAT_LENGTH);
+                UUID id;
+                try
+                {
+                    id = UUID.fromString(name);
+                } catch (IllegalArgumentException iae)
+                {
+                    LOGGER.warn("Found invalid rift name {}", name, iae);
+                    continue;
+                }
+                load(id, file);
+            }
+        } finally
+        {
+            lock.writeLock().unlock();
+        }
+    }
 
-	public void load(UUID id)
-	{
-		File file = new File(dataDirectory, id.toString() + FILE_FORMAT);
-		if (!file.exists())
-		{
-			return;
-		}
-		lock.writeLock().lock();
-		try
-		{
-			load(id, file);
-		} finally
-		{
-			lock.writeLock().unlock();
-		}
-	}
+    public void load(UUID id)
+    {
+        File file = new File(dataDirectory, id.toString() + FILE_FORMAT);
+        if (!file.exists())
+        {
+            return;
+        }
+        lock.writeLock().lock();
+        try
+        {
+            load(id, file);
+        } finally
+        {
+            lock.writeLock().unlock();
+        }
+    }
 
-	private void load(UUID id, File file)
-	{
-		RiftHolder holder = rifts.computeIfAbsent(id, BUILDER);
-		CompoundTag tag;
-		LOGGER.info("Loading rift {}...", id);
-		try
-		{
-			tag = NbtIo.readCompressed(file);
-		} catch (IOException e)
-		{
-			holder.getInventory().clear();
-			LOGGER.error("Could not load rift {}", id, e);
-			return;
-		}
-		holder.getInventoryOrCreate().load(tag);
-	}
+    private void load(UUID id, File file)
+    {
+        RiftHolder holder = rifts.computeIfAbsent(id, BUILDER);
+        CompoundTag tag;
+        LOGGER.info("Loading rift {}...", id);
+        try
+        {
+            tag = NbtIo.readCompressed(file);
+        } catch (IOException e)
+        {
+            holder.getInventory().clear();
+            LOGGER.error("Could not load rift {}", id, e);
+            return;
+        }
+        holder.getInventoryOrCreate().load(tag);
+    }
 
-	public void saveAll()
-	{
-		RiftHolder[] holders;
-		lock.readLock().lock();
-		try
-		{
-			holders = rifts.values().toArray(RiftHolder[]::new);
-		} finally
-		{
-			lock.readLock().unlock();
-		}
-		for (RiftHolder holder : holders)
-		{
-			save(holder);
-		}
-	}
+    public void saveAll()
+    {
+        RiftHolder[] holders;
+        lock.readLock().lock();
+        try
+        {
+            holders = rifts.values().toArray(RiftHolder[]::new);
+        } finally
+        {
+            lock.readLock().unlock();
+        }
+        for (RiftHolder holder : holders)
+        {
+            save(holder);
+        }
+    }
 
-	public void save(UUID id)
-	{
-		lock.readLock().lock();
-		RiftHolder holder;
-		try
-		{
-			holder = rifts.get(id);
-		} finally
-		{
-			lock.readLock().unlock();
-		}
-		save(holder);
-	}
+    public void save(UUID id)
+    {
+        lock.readLock().lock();
+        RiftHolder holder;
+        try
+        {
+            holder = rifts.get(id);
+        } finally
+        {
+            lock.readLock().unlock();
+        }
+        save(holder);
+    }
 
-	private void save(RiftHolder holder)
-	{
-		if (holder == null || !holder.isValid())
-		{
-			return;
-		}
-		String id = holder.getId().toString();
-		RiftInventory inventory = holder.getInventory();
-		File file = new File(dataDirectory, id + FILE_FORMAT);
-		LOGGER.info("Saving rift {}...", id);
-		try
-		{
-			if (!file.exists())
-			{
-				File folder = file.getParentFile();
-				if (folder != null && !folder.exists())
-				{
-					folder.mkdirs();
-				}
-				file.createNewFile();
-			}
-			NbtIo.writeCompressed(inventory.save(), file);
-		} catch (IOException ioexception)
-		{
-			LOGGER.error("Could not save rift {}", id, ioexception);
-		}
-	}
+    private void save(RiftHolder holder)
+    {
+        if (holder == null || !holder.isValid())
+        {
+            return;
+        }
+        String id = holder.getId().toString();
+        RiftInventory inventory = holder.getInventory();
+        File file = new File(dataDirectory, id + FILE_FORMAT);
+        LOGGER.info("Saving rift {}...", id);
+        try
+        {
+            if (!file.exists())
+            {
+                File folder = file.getParentFile();
+                if (folder != null && !folder.exists())
+                {
+                    folder.mkdirs();
+                }
+                file.createNewFile();
+            }
+            NbtIo.writeCompressed(inventory.save(), file);
+        } catch (IOException ioexception)
+        {
+            LOGGER.error("Could not save rift {}", id, ioexception);
+        }
+    }
 
-	@Override
-	public boolean accept(File dir, String name)
-	{
-		return name.endsWith(FILE_FORMAT);
-	}
+    @Override
+    public boolean accept(File dir, String name)
+    {
+        return name.endsWith(FILE_FORMAT);
+    }
 
-	public void walkRifts(BiConsumer<UUID, RiftInventory> riftConsumer)
-	{
-		rifts.forEach((id, holder) -> {
-			if (!holder.isValid())
-			{
-				return;
-			}
-			riftConsumer.accept(id, holder.getInventory());
-		});
-	}
+    public void walkRifts(BiConsumer<UUID, RiftInventory> riftConsumer)
+    {
+        rifts.forEach((id, holder) -> {
+            if (!holder.isValid())
+            {
+                return;
+            }
+            riftConsumer.accept(id, holder.getInventory());
+        });
+    }
 
 }

--- a/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftStorage.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftStorage.java
@@ -22,232 +22,288 @@ import net.minecraft.nbt.NbtIo;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.level.storage.LevelResource;
 
-public class RiftStorage implements FilenameFilter {
+public class RiftStorage implements FilenameFilter
+{
 
-    public static final LevelResource DATA_DIR = new LevelResource("enderrift");
-    public static final String FILE_FORMAT = ".dat";
-    public static final int FILE_FORMAT_LENGTH = FILE_FORMAT.length();
+	public static final LevelResource DATA_DIR = new LevelResource("enderrift");
+	public static final String FILE_FORMAT = ".dat";
+	public static final int FILE_FORMAT_LENGTH = FILE_FORMAT.length();
 
-    private static final Logger LOGGER = LogUtils.getLogger();
-    private static final Function<UUID, RiftHolder> BUILDER = RiftHolder::new;
+	private static final Logger LOGGER = LogUtils.getLogger();
+	private static final Function<UUID, RiftHolder> BUILDER = RiftHolder::new;
 
-    @SuppressWarnings("unchecked")
-    private static final Class<? extends RiftMigration>[] MIGRATIONS = new Class[] {
-        RiftMigration_17_08_2022.class
-    };
+	@SuppressWarnings("unchecked")
+	private static final Class<? extends RiftMigration>[] MIGRATIONS = new Class[]
+	{ RiftMigration_17_08_2022.class };
 
-    private static RiftStorage STORAGE;
+	private static RiftStorage STORAGE;
 
-    public static RiftStorage get() {
-        return STORAGE;
-    }
+	public static RiftStorage get()
+	{
+		return STORAGE;
+	}
 
-    public static boolean isAvailable() {
-        return STORAGE != null;
-    }
+	public static boolean isAvailable()
+	{
+		return STORAGE != null;
+	}
 
-    public static void init(MinecraftServer server) {
-        if (STORAGE != null) {
-            return;
-        }
-        STORAGE = new RiftStorage(server);
-        STORAGE.migrate();
-        STORAGE.loadAll();
-    }
+	public static void init(MinecraftServer server)
+	{
+		if (STORAGE != null)
+		{
+			return;
+		}
+		STORAGE = new RiftStorage(server);
+		STORAGE.migrate();
+		STORAGE.loadAll();
+	}
 
-    public static void deinit() {
-        if (STORAGE == null) {
-            return;
-        }
-        STORAGE.saveAll();
-        STORAGE = null;
-    }
+	public static void deinit()
+	{
+		if (STORAGE == null)
+		{
+			return;
+		}
+		STORAGE.saveAll();
+		STORAGE = null;
+	}
 
-    private final HashMap<UUID, RiftHolder> rifts = new HashMap<>();
-    private final Map<Class<? extends RiftMigration>, RiftMigration> migrations;
-    // ReadLock => Access to the rift data
-    // WriteLock => Modification of rift data
-    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
-    private final File dataDirectory;
+	private final HashMap<UUID, RiftHolder> rifts = new HashMap<>();
+	private final Map<Class<? extends RiftMigration>, RiftMigration> migrations;
+	// ReadLock => Access to the rift data
+	// WriteLock => Modification of rift data
+	private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+	private final File dataDirectory;
 
-    private RiftStorage(MinecraftServer server) {
-        this.dataDirectory = server.getWorldPath(DATA_DIR).toFile();
-        Map<Class<? extends RiftMigration>, RiftMigration> migrations = new HashMap<>();
-        for (Class<? extends RiftMigration> migration : MIGRATIONS) {
-            if (migration == null) {
-                continue;
-            }
-            try {
-                migrations.put(migration, migration.cast(migration.getConstructor().newInstance()));
-            } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException
-                | NoSuchMethodException | SecurityException e) {
-                LOGGER.warn("Failed to load migration '{}'", migration.getSimpleName());
-                continue;
-            }
-        }
-        this.migrations = Collections.unmodifiableMap(migrations);
-    }
+	private RiftStorage(MinecraftServer server)
+	{
+		this.dataDirectory = server.getWorldPath(DATA_DIR).toFile();
+		Map<Class<? extends RiftMigration>, RiftMigration> migrations = new HashMap<>();
+		for (Class<? extends RiftMigration> migration : MIGRATIONS)
+		{
+			if (migration == null)
+			{
+				continue;
+			}
+			try
+			{
+				migrations.put(migration, migration.cast(migration.getConstructor().newInstance()));
+			} catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException | SecurityException e)
+			{
+				LOGGER.warn("Failed to load migration '{}'", migration.getSimpleName());
+				continue;
+			}
+		}
+		this.migrations = Collections.unmodifiableMap(migrations);
+	}
 
-    public <E extends RiftMigration> E getMigration(Class<E> type) {
-        RiftMigration migration = migrations.get(type);
-        if (migration == null) {
-            return null;
-        }
-        return type.cast(migration);
-    }
+	public <E extends RiftMigration> E getMigration(Class<E> type)
+	{
+		RiftMigration migration = migrations.get(type);
+		if (migration == null)
+		{
+			return null;
+		}
+		return type.cast(migration);
+	}
 
-    private void migrate() {
-        for (RiftMigration migration : migrations.values()) {
-            if (!migration.isApplicable(this)) {
-                continue;
-            }
-            LOGGER.info("Running migration '{}'", migration.getName());
-            try {
-                migration.migrate(this);
-            } catch (Exception exp) {
-                LOGGER.warn("Failed to run migration '{}'", migration.getName(), exp);
-            }
-        }
-    }
+	private void migrate()
+	{
+		for (RiftMigration migration : migrations.values())
+		{
+			if (!migration.isApplicable(this))
+			{
+				continue;
+			}
+			LOGGER.info("Running migration '{}'", migration.getName());
+			try
+			{
+				migration.migrate(this);
+			} catch (Exception exp)
+			{
+				LOGGER.warn("Failed to run migration '{}'", migration.getName(), exp);
+			}
+		}
+	}
 
-    public File getDataDirectory() {
-        return dataDirectory;
-    }
+	public File getDataDirectory()
+	{
+		return dataDirectory;
+	}
 
-    public RiftHolder newRift() {
-        UUID id;
-        lock.readLock().lock();
-        try {
-            while (rifts.containsKey(id = UUID.randomUUID())) {
-            }
-            return rifts.computeIfAbsent(id, BUILDER);
-        } finally {
-            lock.readLock().unlock();
-        }
-    }
+	public RiftHolder newRift()
+	{
+		UUID id;
+		lock.readLock().lock();
+		try
+		{
+			while (rifts.containsKey(id = UUID.randomUUID()))
+			{
+			}
+			return rifts.computeIfAbsent(id, BUILDER);
+		} finally
+		{
+			lock.readLock().unlock();
+		}
+	}
 
-    public RiftHolder getRift(UUID id) {
-        if (id == null) {
-            return null;
-        }
-        lock.readLock().lock();
-        try {
-            return rifts.computeIfAbsent(id, BUILDER);
-        } finally {
-            lock.readLock().unlock();
-        }
-    }
+	public RiftHolder getRift(UUID id)
+	{
+		if (id == null)
+		{
+			return null;
+		}
+		lock.readLock().lock();
+		try
+		{
+			return rifts.computeIfAbsent(id, BUILDER);
+		} finally
+		{
+			lock.readLock().unlock();
+		}
+	}
 
-    public void loadAll() {
-        // Prevent others from reading the map before every Rift is fully loaded
-        lock.writeLock().lock();
-        try {
-            if (!dataDirectory.exists()) {
-                return;
-            }
-            File[] files = dataDirectory.listFiles(this);
-            for (File file : files) {
-                String name = file.getName();
-                name = name.substring(0, name.length() - FILE_FORMAT_LENGTH);
-                UUID id;
-                try {
-                    id = UUID.fromString(name);
-                } catch (IllegalArgumentException iae) {
-                    LOGGER.warn("Found invalid rift name {}", name, iae);
-                    continue;
-                }
-                load(id, file);
-            }
-        } finally {
-            lock.writeLock().unlock();
-        }
-    }
+	public void loadAll()
+	{
+		// Prevent others from reading the map before every Rift is fully loaded
+		lock.writeLock().lock();
+		try
+		{
+			if (!dataDirectory.exists())
+			{
+				return;
+			}
+			File[] files = dataDirectory.listFiles(this);
+			for (File file : files)
+			{
+				String name = file.getName();
+				name = name.substring(0, name.length() - FILE_FORMAT_LENGTH);
+				UUID id;
+				try
+				{
+					id = UUID.fromString(name);
+				} catch (IllegalArgumentException iae)
+				{
+					LOGGER.warn("Found invalid rift name {}", name, iae);
+					continue;
+				}
+				load(id, file);
+			}
+		} finally
+		{
+			lock.writeLock().unlock();
+		}
+	}
 
-    public void load(UUID id) {
-        File file = new File(dataDirectory, id.toString() + FILE_FORMAT);
-        if (!file.exists()) {
-            return;
-        }
-        lock.writeLock().lock();
-        try {
-            load(id, file);
-        } finally {
-            lock.writeLock().unlock();
-        }
-    }
+	public void load(UUID id)
+	{
+		File file = new File(dataDirectory, id.toString() + FILE_FORMAT);
+		if (!file.exists())
+		{
+			return;
+		}
+		lock.writeLock().lock();
+		try
+		{
+			load(id, file);
+		} finally
+		{
+			lock.writeLock().unlock();
+		}
+	}
 
-    private void load(UUID id, File file) {
-        RiftHolder holder = rifts.computeIfAbsent(id, BUILDER);
-        CompoundTag tag;
-        LOGGER.info("Loading rift {}...", id);
-        try {
-            tag = NbtIo.readCompressed(file);
-        } catch (IOException e) {
-            holder.getInventory().clear();
-            LOGGER.error("Could not load rift {}", id, e);
-            return;
-        }
-        holder.getInventoryOrCreate().load(tag);
-    }
+	private void load(UUID id, File file)
+	{
+		RiftHolder holder = rifts.computeIfAbsent(id, BUILDER);
+		CompoundTag tag;
+		LOGGER.info("Loading rift {}...", id);
+		try
+		{
+			tag = NbtIo.readCompressed(file);
+		} catch (IOException e)
+		{
+			holder.getInventory().clear();
+			LOGGER.error("Could not load rift {}", id, e);
+			return;
+		}
+		holder.getInventoryOrCreate().load(tag);
+	}
 
-    public void saveAll() {
-        RiftHolder[] holders;
-        lock.readLock().lock();
-        try {
-            holders = rifts.values().toArray(RiftHolder[]::new);
-        } finally {
-            lock.readLock().unlock();
-        }
-        for (RiftHolder holder : holders) {
-            save(holder);
-        }
-    }
+	public void saveAll()
+	{
+		RiftHolder[] holders;
+		lock.readLock().lock();
+		try
+		{
+			holders = rifts.values().toArray(RiftHolder[]::new);
+		} finally
+		{
+			lock.readLock().unlock();
+		}
+		for (RiftHolder holder : holders)
+		{
+			save(holder);
+		}
+	}
 
-    public void save(UUID id) {
-        lock.readLock().lock();
-        RiftHolder holder;
-        try {
-            holder = rifts.get(id);
-        } finally {
-            lock.readLock().unlock();
-        }
-        save(holder);
-    }
+	public void save(UUID id)
+	{
+		lock.readLock().lock();
+		RiftHolder holder;
+		try
+		{
+			holder = rifts.get(id);
+		} finally
+		{
+			lock.readLock().unlock();
+		}
+		save(holder);
+	}
 
-    private void save(RiftHolder holder) {
-        if (holder == null || !holder.isValid()) {
-            return;
-        }
-        String id = holder.getId().toString();
-        RiftInventory inventory = holder.getInventory();
-        File file = new File(dataDirectory, id + FILE_FORMAT);
-        LOGGER.info("Saving rift {}...", id);
-        try {
-            if (!file.exists()) {
-                File folder = file.getParentFile();
-                if (folder != null && !folder.exists()) {
-                    folder.mkdirs();
-                }
-                file.createNewFile();
-            }
-            NbtIo.writeCompressed(inventory.save(), file);
-        } catch (IOException ioexception) {
-            LOGGER.error("Could not save rift {}", id, ioexception);
-        }
-    }
+	private void save(RiftHolder holder)
+	{
+		if (holder == null || !holder.isValid())
+		{
+			return;
+		}
+		String id = holder.getId().toString();
+		RiftInventory inventory = holder.getInventory();
+		File file = new File(dataDirectory, id + FILE_FORMAT);
+		LOGGER.info("Saving rift {}...", id);
+		try
+		{
+			if (!file.exists())
+			{
+				File folder = file.getParentFile();
+				if (folder != null && !folder.exists())
+				{
+					folder.mkdirs();
+				}
+				file.createNewFile();
+			}
+			NbtIo.writeCompressed(inventory.save(), file);
+		} catch (IOException ioexception)
+		{
+			LOGGER.error("Could not save rift {}", id, ioexception);
+		}
+	}
 
-    @Override
-    public boolean accept(File dir, String name) {
-        return name.endsWith(FILE_FORMAT);
-    }
+	@Override
+	public boolean accept(File dir, String name)
+	{
+		return name.endsWith(FILE_FORMAT);
+	}
 
-    public void walkRifts(BiConsumer<UUID, RiftInventory> riftConsumer) {
-        rifts.forEach((id, holder) -> {
-            if (!holder.isValid()) {
-                return;
-            }
-            riftConsumer.accept(id, holder.getInventory());
-        });
-    }
+	public void walkRifts(BiConsumer<UUID, RiftInventory> riftConsumer)
+	{
+		rifts.forEach((id, holder) -> {
+			if (!holder.isValid())
+			{
+				return;
+			}
+			riftConsumer.accept(id, holder.getInventory());
+		});
+	}
 
 }

--- a/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftStorage.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/storage/RiftStorage.java
@@ -1,106 +1,166 @@
 package dev.gigaherz.enderrift.rift.storage;
 
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.ListTag;
-import net.minecraft.nbt.Tag;
-import net.minecraft.world.level.Level;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.level.storage.DimensionDataStorage;
-import net.minecraft.world.level.saveddata.SavedData;
-
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.HashMap;
-import java.util.Map;
+import java.util.UUID;
 import java.util.function.BiConsumer;
+import java.util.function.Function;
 
-public class RiftStorage extends SavedData
-{
-    private static final String DATA_NAME = "enderRiftStorageManager";
+import org.slf4j.Logger;
 
-    private Map<Integer, RiftInventory> rifts = new HashMap<Integer, RiftInventory>();
-    private int lastRiftId;
+import com.mojang.logging.LogUtils;
 
-    public RiftStorage()
-    {
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtIo;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.level.storage.LevelResource;
+
+public class RiftStorage implements FilenameFilter {
+
+    public static final LevelResource DATA_DIR = new LevelResource("enderrift");
+    public static final String FILE_FORMAT = ".dat";
+    public static final int FILE_FORMAT_LENGTH = FILE_FORMAT.length();
+
+    private static final Logger LOGGER = LogUtils.getLogger();
+    private static final Function<UUID, RiftHolder> BUILDER = RiftHolder::new;
+
+    private static RiftStorage STORAGE;
+
+    public static RiftStorage get() {
+        return STORAGE;
     }
 
-    public RiftStorage(CompoundTag nbt)
-    {
-        ListTag riftList = nbt.getList("Rifts", Tag.TAG_COMPOUND);
+    public static boolean isAvailable() {
+        return STORAGE != null;
+    }
 
-        rifts.clear();
-
-        for (int i = 0; i < riftList.size(); ++i)
-        {
-            CompoundTag riftTag = riftList.getCompound(i);
-            int j = riftTag.getByte("Rift");
-
-            RiftInventory inventory = new RiftInventory(this);
-            inventory.readFromNBT(riftTag);
-
-            rifts.put(j, inventory);
+    public static void init(MinecraftServer server) {
+        if(STORAGE != null) {
+            return;
         }
+        STORAGE = new RiftStorage(server);
+        STORAGE.loadAll();
+    }
 
-        lastRiftId = nbt.getInt("LastRiftId");
+    public static void deinit() {
+        if (STORAGE == null) {
+            return;
+        }
+        STORAGE.saveAll();
+        STORAGE = null;
+    }
+
+    private final HashMap<UUID, RiftHolder> rifts = new HashMap<>();
+
+    private final Path dataDirectory;
+
+    private RiftStorage(MinecraftServer server) {
+        this.dataDirectory = server.getWorldPath(DATA_DIR);
+    }
+
+    public RiftHolder newRift() {
+        UUID id;
+        while (rifts.containsKey(id = UUID.randomUUID())) {
+        }
+        return getRift(id);
+    }
+
+    public RiftHolder getRift(UUID id) {
+        if (id == null) {
+            return null;
+        }
+        return rifts.computeIfAbsent(id, BUILDER);
+    }
+
+    public void loadAll() {
+        File folder = dataDirectory.toFile();
+        if (!folder.exists()) {
+            return;
+        }
+        File[] files = folder.listFiles(this);
+        for (File file : files) {
+            String name = file.getName();
+            name = name.substring(0, name.length() - FILE_FORMAT_LENGTH);
+            UUID id;
+            try {
+                id = UUID.fromString(name);
+            } catch (IllegalArgumentException iae) {
+                LOGGER.warn("Found invalid rift name {}", name, iae);
+                continue;
+            }
+            load(id, file);
+        }
+    }
+
+    public void load(UUID id) {
+        File file = dataDirectory.resolve(id.toString() + FILE_FORMAT).toFile();
+        if (!file.exists()) {
+            return;
+        }
+        load(id, file);
+    }
+
+    private void load(UUID id, File file) {
+        RiftHolder holder = rifts.computeIfAbsent(id, BUILDER);
+        holder.resetDirty();
+        CompoundTag tag;
+        try {
+            tag = NbtIo.readCompressed(file);
+        } catch (IOException e) {
+            holder.getInventory().clear();
+            LOGGER.error("Could not load rift {}", id, e);
+            return;
+        }
+        holder.getInventoryOrCreate().load(tag);
+    }
+
+    public void saveAll() {
+        RiftHolder[] holders = rifts.values().toArray(RiftHolder[]::new);
+        for (RiftHolder holder : holders) {
+            save(holder);
+        }
+    }
+
+    public void save(UUID id) {
+        save(rifts.get(id));
+    }
+
+    private void save(RiftHolder holder) {
+        if (holder == null || !holder.isValid() || !holder.isDirty()) {
+            return;
+        }
+        holder.resetDirty();
+        String id = holder.getId().toString();
+        RiftInventory inventory = holder.getInventory();
+        File file = dataDirectory.resolve(id + FILE_FORMAT).toFile();
+        if (!file.exists()) {
+            File folder = file.getParentFile();
+            if (!folder.exists()) {
+                folder.mkdirs();
+            }
+        }
+        try {
+            NbtIo.writeCompressed(inventory.save(), file);
+        } catch (IOException ioexception) {
+            LOGGER.error("Could not rift {}", id, ioexception);
+        }
     }
 
     @Override
-    public CompoundTag save(CompoundTag nbtTagCompound)
-    {
-        ListTag nbtTagList = new ListTag();
-
-        for (Map.Entry<Integer, RiftInventory> entry : rifts.entrySet())
-        {
-            RiftInventory inventory = entry.getValue();
-
-            CompoundTag nbtTagCompound1 = new CompoundTag();
-            nbtTagCompound1.putInt("Rift", entry.getKey());
-            inventory.writeToNBT(nbtTagCompound1);
-            nbtTagList.add(nbtTagCompound1);
-        }
-
-        nbtTagCompound.put("Rifts", nbtTagList);
-        nbtTagCompound.putInt("LastRiftId", lastRiftId);
-
-        return nbtTagCompound;
+    public boolean accept(File dir, String name) {
+        return name.endsWith(FILE_FORMAT);
     }
 
-    public static RiftStorage get(Level world)
-    {
-        if (!(world instanceof ServerLevel))
-        {
-            throw new RuntimeException("Attempted to get the data from a client world. This is wrong.");
-        }
-
-        ServerLevel overworld = world.getServer().getLevel(Level.OVERWORLD);
-
-        DimensionDataStorage storage = overworld.getDataStorage();
-        return storage.computeIfAbsent(RiftStorage::new, RiftStorage::new, DATA_NAME);
-    }
-
-    public RiftInventory getRift(int id)
-    {
-        RiftInventory rift = rifts.get(id);
-
-        if (rift == null)
-        {
-            rift = new RiftInventory(this);
-            rifts.put(id, rift);
-            setDirty();
-        }
-
-        return rift;
-    }
-
-    public int getNextRiftId()
-    {
-        setDirty();
-
-        return ++lastRiftId;
-    }
-
-    public void walkExistingRifts(BiConsumer<Integer, RiftInventory> consumer)
-    {
-        rifts.forEach(consumer);
+    public void walkRifts(BiConsumer<UUID, RiftInventory> riftConsumer) {
+        rifts.forEach((id, holder) -> {
+            if (!holder.isValid()) {
+                return;
+            }
+            riftConsumer.accept(id, holder.getInventory());
+        });
     }
 
 }

--- a/src/main/java/dev/gigaherz/enderrift/rift/storage/migration/RiftMigration_17_08_2022.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/storage/migration/RiftMigration_17_08_2022.java
@@ -17,50 +17,50 @@ import net.minecraft.world.item.ItemStack;
 public class RiftMigration_17_08_2022 extends RiftMigration
 {
 
-	private final HashMap<Integer, UUID> map = new HashMap<>();
+    private final HashMap<Integer, UUID> map = new HashMap<>();
 
-	public UUID getMigratedId(int id)
-	{
-		return map.get(id);
-	}
+    public UUID getMigratedId(int id)
+    {
+        return map.get(id);
+    }
 
-	@Override
-	public void migrate(RiftStorage storage) throws Exception
-	{
-		File oldStorage = new File(storage.getDataDirectory(), "../data/enderRiftStorageManager.dat");
-		CompoundTag tag = NbtIo.readCompressed(oldStorage);
-		CompoundTag data = tag.getCompound("data");
-		ListTag rifts = data.getList("Rifts", Tag.TAG_COMPOUND);
-		for (int index = 0; index < rifts.size(); index++)
-		{
-			CompoundTag riftTag = rifts.getCompound(index);
-			int riftId = riftTag.getByte("Rift");
-			ListTag items = riftTag.getList("Items", Tag.TAG_COMPOUND);
-			RiftHolder holder = storage.newRift();
-			map.put(riftId, holder.getId());
-			RiftInventory inventory = holder.getInventoryOrCreate();
-			for (int i = 0; i < items.size(); i++)
-			{
-				ItemStack itemStack = ItemStack.of(items.getCompound(i));
-				if (!inventory.isItemValid(i, itemStack))
-				{
-					continue;
-				}
-				inventory.insertItem(i, itemStack, false);
-			}
-		}
-	}
+    @Override
+    public void migrate(RiftStorage storage) throws Exception
+    {
+        File oldStorage = new File(storage.getDataDirectory(), "../data/enderRiftStorageManager.dat");
+        CompoundTag tag = NbtIo.readCompressed(oldStorage);
+        CompoundTag data = tag.getCompound("data");
+        ListTag rifts = data.getList("Rifts", Tag.TAG_COMPOUND);
+        for (int index = 0; index < rifts.size(); index++)
+        {
+            CompoundTag riftTag = rifts.getCompound(index);
+            int riftId = riftTag.getByte("Rift");
+            ListTag items = riftTag.getList("Items", Tag.TAG_COMPOUND);
+            RiftHolder holder = storage.newRift();
+            map.put(riftId, holder.getId());
+            RiftInventory inventory = holder.getInventoryOrCreate();
+            for (int i = 0; i < items.size(); i++)
+            {
+                ItemStack itemStack = ItemStack.of(items.getCompound(i));
+                if (!inventory.isItemValid(i, itemStack))
+                {
+                    continue;
+                }
+                inventory.insertItem(i, itemStack, false);
+            }
+        }
+    }
 
-	@Override
-	protected String getName()
-	{
-		return "Old integer ids to new UUID storage system";
-	}
+    @Override
+    protected String getName()
+    {
+        return "Old integer ids to new UUID storage system";
+    }
 
-	@Override
-	protected boolean isApplicable(RiftStorage storage)
-	{
-		return new File(storage.getDataDirectory(), "../data/enderRiftStorageManager.dat").exists();
-	}
+    @Override
+    protected boolean isApplicable(RiftStorage storage)
+    {
+        return new File(storage.getDataDirectory(), "../data/enderRiftStorageManager.dat").exists();
+    }
 
 }

--- a/src/main/java/dev/gigaherz/enderrift/rift/storage/migration/RiftMigration_17_08_2022.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/storage/migration/RiftMigration_17_08_2022.java
@@ -14,45 +14,53 @@ import net.minecraft.nbt.NbtIo;
 import net.minecraft.nbt.Tag;
 import net.minecraft.world.item.ItemStack;
 
-public class RiftMigration_17_08_2022 extends RiftMigration {
+public class RiftMigration_17_08_2022 extends RiftMigration
+{
 
-    private final HashMap<Integer, UUID> map = new HashMap<>();
+	private final HashMap<Integer, UUID> map = new HashMap<>();
 
-    public UUID getMigratedId(int id) {
-        return map.get(id);
-    }
+	public UUID getMigratedId(int id)
+	{
+		return map.get(id);
+	}
 
-    @Override
-    public void migrate(RiftStorage storage) throws Exception {
-        File oldStorage = new File(storage.getDataDirectory(), "../data/enderRiftStorageManager.dat");
-        CompoundTag tag = NbtIo.readCompressed(oldStorage);
-        CompoundTag data = tag.getCompound("data");
-        ListTag rifts = data.getList("Rifts", Tag.TAG_COMPOUND);
-        for (int index = 0; index < rifts.size(); index++) {
-            CompoundTag riftTag = rifts.getCompound(index);
-            int riftId = riftTag.getByte("Rift");
-            ListTag items = riftTag.getList("Items", Tag.TAG_COMPOUND);
-            RiftHolder holder = storage.newRift();
-            map.put(riftId, holder.getId());
-            RiftInventory inventory = holder.getInventoryOrCreate();
-            for (int i = 0; i < items.size(); i++) {
-                ItemStack itemStack = ItemStack.of(items.getCompound(i));
-                if (!inventory.isItemValid(i, itemStack)) {
-                    continue;
-                }
-                inventory.insertItem(i, itemStack, false);
-            }
-        }
-    }
+	@Override
+	public void migrate(RiftStorage storage) throws Exception
+	{
+		File oldStorage = new File(storage.getDataDirectory(), "../data/enderRiftStorageManager.dat");
+		CompoundTag tag = NbtIo.readCompressed(oldStorage);
+		CompoundTag data = tag.getCompound("data");
+		ListTag rifts = data.getList("Rifts", Tag.TAG_COMPOUND);
+		for (int index = 0; index < rifts.size(); index++)
+		{
+			CompoundTag riftTag = rifts.getCompound(index);
+			int riftId = riftTag.getByte("Rift");
+			ListTag items = riftTag.getList("Items", Tag.TAG_COMPOUND);
+			RiftHolder holder = storage.newRift();
+			map.put(riftId, holder.getId());
+			RiftInventory inventory = holder.getInventoryOrCreate();
+			for (int i = 0; i < items.size(); i++)
+			{
+				ItemStack itemStack = ItemStack.of(items.getCompound(i));
+				if (!inventory.isItemValid(i, itemStack))
+				{
+					continue;
+				}
+				inventory.insertItem(i, itemStack, false);
+			}
+		}
+	}
 
-    @Override
-    protected String getName() {
-        return "Old integer ids to new UUID storage system";
-    }
+	@Override
+	protected String getName()
+	{
+		return "Old integer ids to new UUID storage system";
+	}
 
-    @Override
-    protected boolean isApplicable(RiftStorage storage) {
-        return new File(storage.getDataDirectory(), "../data/enderRiftStorageManager.dat").exists();
-    }
+	@Override
+	protected boolean isApplicable(RiftStorage storage)
+	{
+		return new File(storage.getDataDirectory(), "../data/enderRiftStorageManager.dat").exists();
+	}
 
 }

--- a/src/main/java/dev/gigaherz/enderrift/rift/storage/migration/RiftMigration_17_08_2022.java
+++ b/src/main/java/dev/gigaherz/enderrift/rift/storage/migration/RiftMigration_17_08_2022.java
@@ -1,0 +1,58 @@
+package dev.gigaherz.enderrift.rift.storage.migration;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.UUID;
+
+import dev.gigaherz.enderrift.rift.storage.RiftHolder;
+import dev.gigaherz.enderrift.rift.storage.RiftInventory;
+import dev.gigaherz.enderrift.rift.storage.RiftMigration;
+import dev.gigaherz.enderrift.rift.storage.RiftStorage;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.NbtIo;
+import net.minecraft.nbt.Tag;
+import net.minecraft.world.item.ItemStack;
+
+public class RiftMigration_17_08_2022 extends RiftMigration {
+
+    private final HashMap<Integer, UUID> map = new HashMap<>();
+
+    public UUID getMigratedId(int id) {
+        return map.get(id);
+    }
+
+    @Override
+    public void migrate(RiftStorage storage) throws Exception {
+        File oldStorage = new File(storage.getDataDirectory(), "../data/enderRiftStorageManager.dat");
+        CompoundTag tag = NbtIo.readCompressed(oldStorage);
+        CompoundTag data = tag.getCompound("data");
+        ListTag rifts = data.getList("Rifts", Tag.TAG_COMPOUND);
+        for (int index = 0; index < rifts.size(); index++) {
+            CompoundTag riftTag = rifts.getCompound(index);
+            int riftId = riftTag.getByte("Rift");
+            ListTag items = riftTag.getList("Items", Tag.TAG_COMPOUND);
+            RiftHolder holder = storage.newRift();
+            map.put(riftId, holder.getId());
+            RiftInventory inventory = holder.getInventoryOrCreate();
+            for (int i = 0; i < items.size(); i++) {
+                ItemStack itemStack = ItemStack.of(items.getCompound(i));
+                if (!inventory.isItemValid(i, itemStack)) {
+                    continue;
+                }
+                inventory.insertItem(i, itemStack, false);
+            }
+        }
+    }
+
+    @Override
+    protected String getName() {
+        return "Old integer ids to new UUID storage system";
+    }
+
+    @Override
+    protected boolean isApplicable(RiftStorage storage) {
+        return new File(storage.getDataDirectory(), "../data/enderRiftStorageManager.dat").exists();
+    }
+
+}

--- a/src/main/resources/assets/enderrift/blockstates/debug_item_block.json
+++ b/src/main/resources/assets/enderrift/blockstates/debug_item_block.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "enderrift:block/debug_item_block"
+    }
+  }
+}

--- a/src/main/resources/assets/enderrift/lang/de_de.json
+++ b/src/main/resources/assets/enderrift/lang/de_de.json
@@ -1,4 +1,5 @@
 {
+    "block.enderrift.debug_item_block": "Zufälliger Item Generator",
     "block.enderrift.rift": "Ender-Rift-Kern",
     "block.enderrift.structure": "Ender-Rift-Struktur",
     "block.enderrift.interface": "Riftinterface",

--- a/src/main/resources/assets/enderrift/lang/en_us.json
+++ b/src/main/resources/assets/enderrift/lang/en_us.json
@@ -1,4 +1,5 @@
 {
+    "block.enderrift.debug_item_block": "Random Item Generator",
     "block.enderrift.rift": "Ender-Rift Core",
     "block.enderrift.structure": "Ender-Rift Structure",
     "block.enderrift.interface": "Automation Interface",

--- a/src/main/resources/assets/enderrift/models/block/debug_item_block.json
+++ b/src/main/resources/assets/enderrift/models/block/debug_item_block.json
@@ -1,0 +1,9 @@
+{
+  "parent": "block/block",
+  "loader": "forge:obj",
+  "model": "enderrift:models/block/driver_main.obj",
+  "textures": {
+    "all": "enderrift:block/browser",
+    "particle": "#all"
+  }
+}

--- a/src/main/resources/assets/enderrift/models/item/debug_item_block.json
+++ b/src/main/resources/assets/enderrift/models/item/debug_item_block.json
@@ -1,0 +1,3 @@
+{
+  "parent": "enderrift:block/debug_item_block"
+}


### PR DESCRIPTION
This PR introduces a more performance friendly storage system for the rift inventory
It also allows to have more than 256 rifts (the old implemention used getByte("Rift") to get the id)
All rifts have a UUID instead of an numeric id and their own file making it easier to get rid of them

This PR also adds a random item generator block for debugging purposes if needed I can strip it again
To test stuff using this mod I added PipeZ, Spark, SolarGeneration and EdivadLib for testing, I commented for the time being